### PR TITLE
minor fix passing parameters to external file

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -190,6 +190,7 @@ int broadcast(char *message) {
 		if(strlen(processfile) > 0) {
 			char cmd[255];
 			strcpy(cmd,processfile);
+			strcat(cmd," ");
 			strcat(cmd,message);
 			f=popen(cmd, "r");
 			pclose(f);


### PR DESCRIPTION
added a space between the external file location and passed along parameters.
