### PR TITLE
My quigg: quigg_switch: Allow unit_id 0 ... 5

### DIFF
--- a/libs/protocols/quigg_switch.c
+++ b/libs/protocols/quigg_switch.c
@@ -174,7 +174,6 @@ int quiggSwCreateCode(JsonNode *code) {
 		state=0;
 	else if(json_find_number(code, "on", &itmp) == 0)
 		state=1;
-
 	if(id==-1 || (unit==-1 && all==0) || state==-1) {
 		logprintf(LOG_ERR, "quigg_switch: insufficient number of arguments");
 		return EXIT_FAILURE;


### PR DESCRIPTION
increased the valid range for unit id to 5:
0-3 to operate the four switches,
4 for the unlabeled button on the GT-7000 remote control (Dimmer ?)
5 for the Master Button (operate command on all switches)
