### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ foreach (file \${files})
 endforeach(file)
 
 execute_process(COMMAND update-rc.d pilight remove)
-execute_process(COMMAND ln -sf /usr/local/lib/pilight/libpilight.so.3 /usr/local/lib/libpilight.so)
+execute_process(COMMAND ln -sf /usr/local/lib/pilight/libpilight.so.5.0 /usr/local/lib/libpilight.so)
 execute_process(COMMAND ldconfig)
 
 ") # END of appending to file...


### PR DESCRIPTION
Fixed building by setup.sh from scratch (updated library number)
Without that bug fix there were error 'libpilight.so' not found during starting ilight service
