### PR TITLE
Receive example - a way to send value to pilight-core

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -1077,7 +1077,7 @@ static void client_controller_parse_code(int i, JsonNode *json) {
             }
 
             char * pname;
-            json_find_string(json, "protocol", &pname)
+            json_find_string(json, "protocol", &pname);
 		    pilight.broadcast(pname, json);
         }
     }
@@ -1201,6 +1201,8 @@ static void socket_parse_data(int i, char *buffer) {
 		if(json_validate(buffer) == true) {
 #endif
 			json = json_decode(buffer);
+            char *output = json_stringify(json, NULL);
+            logprintf(LOG_DEBUG, "socket_parse_data valid json: %s", output);
 
 			/* The incognito mode is used by the daemon to emulate certain clients.
 			   Temporary change the client type from the node mode to the emulated

--- a/daemon.c
+++ b/daemon.c
@@ -1068,7 +1068,24 @@ static void client_controller_parse_code(int i, JsonNode *json) {
 				}
 			}
 		}
-	}
+        else if(strcmp(message, "receiver") == 0) {
+			char *output = json_stringify(json, NULL);
+			logprintf(LOG_DEBUG, "controll_reciver %s", output);
+            JsonNode *jsettings = NULL;
+            if((jsettings = json_find_member(json, "message")) != NULL ) {
+                json_remove_from_parent(jsettings);
+            }
+
+            char * pname;
+            json_find_string(json, "protocol", &pname)
+		    pilight.broadcast(pname, json);
+        }
+    }
+    else if(json_find_string(json, "protocol", &message) == 0) {
+		char *output = json_stringify(json, NULL);
+		logprintf(LOG_DEBUG, "controll_reciver2 %s", output);
+	    pilight.broadcast(message, json);
+    }
 }
 
 #ifdef WEBSERVER
@@ -1268,7 +1285,19 @@ static void socket_parse_data(int i, char *buffer) {
 					incognito_mode = 0;
 				}
 			}
-
+            else if(json_find_string(json, "origin", &message) == 0) {
+				logprintf(LOG_DEBUG, "socket_parse_data ELOR: %s", output);
+                if(strcmp(message, "receiver") == 0) {
+					client_controller_parse_code(-1, json);
+                }
+                else{
+				    logprintf(LOG_DEBUG, "socket_parse_data ELOR: not %s", message);
+                }
+            } 
+			else {
+				logprintf(LOG_DEBUG, "socket_parse_data ELSE: %s", output);
+			}
+            
 			if(handshakes[i] == -1 && socket_get_clients(i) > 0) {
 				socket_write(sd, "{\"message\":\"reject client\"}");
 				socket_close(sd);

--- a/socket_message_example
+++ b/socket_message_example
@@ -1,0 +1,6 @@
+{"message":"client controller"}
+{"message":"accept client"}
+
+{"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
+{"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
+

--- a/socket_message_example
+++ b/socket_message_example
@@ -1,6 +1,39 @@
+Set TCP session
+I do use netcat:
+
+$nc 127.0.0.1 51222
+
+and then send:
 {"message":"client controller"}
-{"message":"accept client"}
+(response){"message":"accept client"}
 
 {"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
 {"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
+
+
+
+Would generate on console:
+socket:{"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
+console:
+[Jan 25 18:08:07:995150] pilight-daemon: DEBUG: socket recv: {"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
+[Jan 25 18:08:07:995854] pilight-daemon: DEBUG: socket_parse_data valid json: {"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
+[Jan 25 18:08:07:996119] pilight-daemon: DEBUG: socket_parse_data ELOR: {"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
+[Jan 25 18:08:07:996475] pilight-daemon: DEBUG: controll_reciver2 {"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
+[   Jan 25 18:08:08:509] pilight-daemon: DEBUG: socket write succeeded: {"origin":"config","type":3,"devices":{"living":[ "weather2" ]},"values":{"timestamp":1422205687,"temperature":1500}}
+
+[  Jan 25 18:08:08:7357] pilight-daemon: DEBUG: broadcasted: {"origin":"config","type":3,"devices":{"living":[ "weather2" ]},"values":{"timestamp":1422205687,"temperature":1500}}
+[ Jan 25 18:08:08:10663] pilight-daemon: DEBUG: broadcasted: {"code":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}
+
+
+
+We could change system state of a device (in this example = switch), without sendig a code (not sure how usefull is that, but as an example - we can ovveride settings "for the future" without affecting current device state => new state should saved on pilight daemon stop)
+
+socket:
+{"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
+console:
+[Jan 25 18:09:28:193752] pilight-daemon: DEBUG: socket recv: {"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
+[Jan 25 18:09:28:194357] pilight-daemon: DEBUG: socket_parse_data valid json: {"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
+[Jan 25 18:09:28:194623] pilight-daemon: DEBUG: socket_parse_data ELOR: {"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
+[Jan 25 18:09:28:194959] pilight-daemon: DEBUG: controll_reciver2 {"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
+[Jan 25 18:09:28:196682] pilight-daemon: DEBUG: broadcasted: {"code":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver","uuid":"0000-00-00-46-99cc08"}
 


### PR DESCRIPTION
This is an example for my question
http://forum.pilight.org/Thread-pilight-emulating-api-custom-daemon-as-a-data-input

The initial idea is: 
"Send/receive any receive code into core (config) of pilight"

The goal:
Connect non-pilight-compatible device with pilight-daemon.
In my case - I did want to send temperature values to the node defined in the system.
        "weather2": {
            "name": "Weather2",   
            "protocol": [ "alecto_wsd17" ],
            "id": [{
                "id": 4
            }],
            "temperature": 1469,  
        },

Here, I can connect to pilight-daemon (via any tcp socket)

{"message":"client controller"}
and send a "fake" receive message:
{"message":{"id":4,"temperature":1500},"origin":"receiver","protocol":"alecto_wsd17","uuid":"0000-00-00-46-99cc08"}

The same could be used to override device (switch) state without sending the signal
{"message":{"id":"B1","unit":34,"state":"on"},"protocol":"clarus_switch","origin":"receiver"}
(this would create change in system, without sending the code)


----------
Probably merge to current master is not a good idea :) but I would like to present this solution for further discussion.
With my current knowledge of the code I would consider implementation of this functionality via webserver Since it does support (conn->uri, "/send") and (conn->uri, "/config") it would be nice to have (conn->uri, "/receive"),  or could we allow sending value via (conn->uri, "/values")?

What is Your opinion?
It would be nice to build into api emulation of receive protocol.


==================
PS
Currently I can communicate with pilight daemon via 2-3 tcp sockets:
- client receiver to capture codes from gui or internall daemon
- client sender to send custom codes form my python-daemon
- client controller to send temperature value

The final goal it to write python-daemon as a controller (like gui) and communicate with daemon (via api?). Since python code is easy to manage it would create quick way for complicated tasks (in addition to "Rules" provided by pilight)