### PR TITLE
X10 protocol - Bugfixing State condition

### DIFF
--- a/libs/protocols/x10.c
+++ b/libs/protocols/x10.c
@@ -133,9 +133,9 @@ static void x10CreateNumber(int n) {
 		x10CreateLow(56, 56);
 	}
 }
-
+// Off: Bit 5 is High also set complement bit
 static void x10CreateState(int state) {
-	if(state == 0) {
+	if(state == 1) {
 		x10CreateHigh(36, 36);
 		x10CreateLow(52, 52);
 	}
@@ -216,7 +216,7 @@ void x10Init(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "x10";
-	module->version = "1.2";
+	module->version = "1.21";
 	module->reqversion = "5.0";
 	module->reqcommit = "84";
 }


### PR DESCRIPTION
Bugfixing X10 protocol: state condition does not match
L41 defines state==1 as off
L161 defines state ==1 as off
CM17A protocol defines that A1OFF has Bit 5 set to 1 -> x10CreateHigh(36,36)