### PR TITLE
Modified raw module with structured printout

### DIFF
--- a/raw.c
+++ b/raw.c
@@ -89,13 +89,19 @@ int main_gc(void) {
 }
 
 void *receiveOOK(void *param) {
-	int duration = 0;
+	int duration = 0, iLoop = 0;
 
 	struct hardware_t *hw = (hardware_t *)param;
 	while(main_loop && hw->receiveOOK) {
 		duration = hw->receiveOOK();
+		iLoop++;
 		if(duration > 0) {
-			printf("%s: %d\n", hw->id, duration);
+			if (duration > 5100) {
+				printf(" %d -#: %d\n%s: ",duration, iLoop, hw->id);
+				iLoop = 0;
+			} else {
+				printf(" %d", duration);
+			}
 		}
 	};
 	return NULL;
@@ -113,7 +119,9 @@ void *receivePulseTrain(void *param) {
 			break;
 		} else if(r.length > 0) {
 			for(i=0;i<r.length;i++) {
-				printf("%s: %d\n", hw->id, r.pulses[i]);
+//				printf("%s: %d\n", hw->id, r.pulses[i]);
+				printf(" %d", r.pulses[i]);
+				if (r.pulses[i]>5100) printf(" -# %d\n %s:",i,hw->id);
 			}
 		}
 	};


### PR DESCRIPTION
The current version of pilight-raw prints the hardware id before each pulse and inserts a CR after each pulse. This version will insert a CR only if the generic footer condition is true, e.q. a pulse with a duration > 5100 is found, and will add the hardware id after the CR.
This will greatly simplify recognition of pulsetrains and allow easy copy of pulsetrains to pilight-send with the raw option.
The drawback may be on machines with multiple hardware boards and on a distributed ADHOC network, receiving data at the same time, this scenario is not tested, and not each single pulse is prefixed with the hardware id, thus perhaps this version should be made available as pilight-rawf (f for formatted).