### PR TITLE
fixed bug in x.10 protocol

### DIFF
--- a/libs/pilight/protocols/433.92/x10.c
+++ b/libs/pilight/protocols/433.92/x10.c
@@ -134,7 +134,7 @@ static void createLetter(int l) {
 }
 
 static void createNumber(int n) {
-	if(n >= 8) {
+	if(n > 8) {
 		createHigh(10, 10);
 		createLow(26, 26);
 		n -= 8;


### PR DESCRIPTION
This bug caused sending of the same raw codes for unit codes with a numeric part of 8 and 9.