### PR TITLE
Allow any pin number for parameter gpio

### DIFF
--- a/libs/pilight/protocols/GPIO/gpio_switch.c
+++ b/libs/pilight/protocols/GPIO/gpio_switch.c
@@ -171,7 +171,7 @@ void gpioSwitchInit(void) {
 
 	options_add(&gpio_switch->options, 't', "on", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
 	options_add(&gpio_switch->options, 'f', "off", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
-	options_add(&gpio_switch->options, 'g', "gpio", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^([0-9]{1}|1[0-9]|20)$");
+	options_add(&gpio_switch->options, 'g', "gpio", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "[0-9]");
 
 	options_add(&gpio_switch->options, 0, "readonly", OPTION_HAS_VALUE, GUI_SETTING, JSON_NUMBER, (void *)1, "^[10]{1}$");
 	options_add(&gpio_switch->options, 0, "confirm", OPTION_HAS_VALUE, GUI_SETTING, JSON_NUMBER, (void *)1, "^[10]{1}$");


### PR DESCRIPTION
I don't know what I'm doing, I haven't tested it and I just copied this part from https://github.com/pilight/pilight/blob/master/libs/pilight/protocols/GPIO/relay.c
So please verify and/or test thoroughly :)
This hopefully fixes http://forum.pilight.org/Thread-Bug-report-gpio-switch-does-not-accept-high-pin-numbers