### PR TITLE
Fix compiler warning: unknown escape sequence: '\d'

### DIFF
--- a/libs/pilight/protocols/433.92/ev1527.c
+++ b/libs/pilight/protocols/433.92/ev1527.c
@@ -88,7 +88,7 @@ void ev1527Init(void) {
 	ev1527->maxgaplen = MAX_PULSE_LENGTH*PULSE_DIV;
 	ev1527->mingaplen = MIN_PULSE_LENGTH*PULSE_DIV;
 
-	options_add(&ev1527->options, 'u', "unitcode", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^(104857[0-5]|10485[0-6]\d|1048[0-4]\d\d|104[0-7]\d{3}|10[0-3]\d{4}|0?\d{1,6})$");
+	options_add(&ev1527->options, 'u', "unitcode", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^(104857[0-5]|10485[0-6][0-9]|1048[0-4][0-9][0-9]|104[0-7][0-9]{3}|10[0-3][0-9]{4}|0?[0-9]{1,6})$");
 	options_add(&ev1527->options, 't', "opened", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
 	options_add(&ev1527->options, 'f', "closed", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
 


### PR DESCRIPTION
The escape sequence \d is not known to all compilers. Thus I replaced it with [0-9].