### PR TITLE
Fix potential NULL pointer access in json_strdup().

### DIFF
--- a/libs/pilight/core/json.c
+++ b/libs/pilight/core/json.c
@@ -39,9 +39,9 @@
 static char *json_strdup(const char *str)
 {
 	char *ret = (char*) malloc(strlen(str) + 1);
-	memset(ret, 0, strlen(str) + 1);
 	if (ret == NULL)
 		out_of_memory();
+	memset(ret, 0, strlen(str) + 1);
 	strcpy(ret, str);
 	return ret;
 }


### PR DESCRIPTION
If out-of-memory happend in json_strdup() the application crashed due to a
segmentation fault rather then terminate regularly. This has been fixed.