### PR TITLE
Fix incomplete buffer initialization.

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -830,7 +830,7 @@ static int send_queue(struct JsonNode *json, enum origin_t origin) {
 				}
 				jprotocol = jprotocol->next;
 			}
-			memset(raw, 0, MAXPULSESTREAMLENGTH-1);
+			memset(raw, 0, sizeof(raw));
 			protocol->raw = raw;
 			if(match == 1 && protocol->createCode != NULL) {
 				/* Let the protocol create his code */

--- a/debug.c
+++ b/debug.c
@@ -103,7 +103,7 @@ void *receivePulseTrain(void *param) {
 	struct hardware_t *hw = (hardware_t *)param;
 
 	while(main_loop) {
-		memset(&r.pulses, 0, MAXPULSESTREAMLENGTH);
+		memset(&r.pulses, 0, sizeof(r.pulses));
 		memset(&tm, '\0', sizeof(struct tm));
 		pulse = 0;
 		inner_loop = 1;
@@ -183,8 +183,8 @@ void *receiveOOK(void *param) {
 	struct hardware_t *hw = (hardware_t *)param;
 
 	while(main_loop) {
-		memset(&raw, '\0', MAXPULSESTREAMLENGTH);
-		memset(&pRaw, '\0', MAXPULSESTREAMLENGTH);
+		memset(&raw, '\0', sizeof(raw));
+		memset(&pRaw, '\0', sizeof(pRaw));
 		memset(&tm, '\0', sizeof(struct tm));
 		recording = 1;
 		bit = 0;


### PR DESCRIPTION
Fix memset-length parameter when initializing buffers that are arrays of
elements larger than byte (multiply the length by sizeof(buffer[0])
or just use sizeof(buffer)).