### PR TITLE
Fix buffer overflow in setenv() and unsetenv() functions.

### DIFF
--- a/libs/pilight/core/common.c
+++ b/libs/pilight/core/common.c
@@ -161,10 +161,17 @@ int check_instances(const wchar_t *prog) {
 }
 
 int setenv(const char *name, const char *value, int overwrite) {
-	if(overwrite == 0) {
-		value = getenv(name);
+	if(name == NULL) {
+		errno = EINVAL;
+		return -1;
 	}
-	char c[strlen(name)+strlen(value)+1];
+	if(overwrite == 0 && getenv(name) != NULL) {
+		return 0; // name already defined and not allowed to overwrite. Treat as OK.
+	}
+	if(value == NULL) {
+		return unsetenv(name);
+	}
+	char c[strlen(name)+1+strlen(value)+1]; // one for "=" + one for term zero
 	strcat(c, name);
 	strcat(c, "=");
 	strcat(c, value);
@@ -172,7 +179,11 @@ int setenv(const char *name, const char *value, int overwrite) {
 }
 
 int unsetenv(const char *name) {
-	char c[strlen(name)+1];
+	if(name == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+	char c[strlen(name)+1+1]; // one for "=" + one for term zero
 	strcat(c, name);
 	strcat(c, "=");
 	return putenv(c);


### PR DESCRIPTION
A buffer allocated by setenv() and unsetenv() was one byte too short.
If setenv() was called with option to not overwrite an existing variable
and that variable does not exist, then a NULL pointer was used and a
segfault happens (if the variable exists, it was unnecessary set again
to its current value). All this has been fixed.

Further the parameters passed to setenv() and unsetenv() are now checked
against NULL pointers and the functions do the best they can do without
crashing (return with failure indicator and errno set). This introduced
a feature for setenv() that, if called with a variable name but a value
of NULL, it does an unsetenv().