### PR TITLE
alecto_wx500: Fix negative temperatures

### DIFF
--- a/libs/pilight/protocols/433.92/alecto_wx500.c
+++ b/libs/pilight/protocols/433.92/alecto_wx500.c
@@ -134,15 +134,19 @@ static void parseCode(void) {
 		type = 0x5;
 		return;
 	}
-
+	
 	alecto_wx500->message = json_mkobject();
 	switch(type) {
 		case 1:
 			id = binToDec(binary, 0, 7);
-			temperature = (double)(binToDec(binary, 12, 22))/10.0;
+			temperature = (double)(binToDec(binary, 12, 23)) / 10.0;
 			humidity = (binToDec(binary, 28, 31) * 10) + binToDec(binary, 24,27);
 			battery = !binary[8];
-
+			
+			if ((int)(binToDec(binary, 23, 23)) == 1) {
+				temperature -= 409.6;
+			}
+			
 			temperature += temp_offset;
 			humidity += humi_offset;
 


### PR DESCRIPTION
This fix works by reading a signed bit from the code, indicating whether the temperature should be positive or negative. Original fix by Tommybear1979.