### PR TITLE
Requiring network before starting the service.

### DIFF
--- a/res/init/pilight.initd
+++ b/res/init/pilight.initd
@@ -1,7 +1,7 @@
 #! /bin/sh
 ### BEGIN INIT INFO
 # Provides:          pilight-daemon
-# Required-Start:    $remote_fs $syslog
+# Required-Start:    $network $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
This fixes "Service does not start correctly when booting" on Raspberry PI 2
https://forum.pilight.org/Thread-Service-does-not-start-correctly-when-booting