### PR TITLE
fix buffer overflow in elro_300_switch protocol

### DIFF
--- a/libs/pilight/protocols/433.92/elro_300_switch.c
+++ b/libs/pilight/protocols/433.92/elro_300_switch.c
@@ -87,8 +87,12 @@ static void parseCode(void) {
 
 	for(i=0; i < elro_300_switch->rawlen; i++) {
 		if(elro_300_switch->raw[i] > (int)((double)AVG_PULSE_LENGTH*((double)PULSE_MULTIPLIER/2))) {
-			binary[x++] = 1;
-		} else {
+			if(i&1) {
+				binary[x++] = 1;
+			} else {
+				return; // even pulse lengths must be low
+			}
+		} else if(i&1) {
 			binary[x++] = 0;
 		}
 	}


### PR DESCRIPTION
Because the rawlen array has twice the size of the binary array there is currently a buffer overflow which can make pilight crash. This happened for my but the event was triggered by RF noise. Unfortunately I have no device using the elro_300_switch protocol so that I could test the changed code. But with this code there are no longer crashes.