### PR TITLE
fix alecto_wx500 protocol

### DIFF
--- a/libs/pilight/protocols/433.92/alecto_wx500.c
+++ b/libs/pilight/protocols/433.92/alecto_wx500.c
@@ -70,7 +70,7 @@ static void parseCode(void) {
 	int n4 = 0, n5 = 0, n6 = 0, n7 = 0, n8 = 0;
 	int checksum = 1;
 
-	for(x=1;x<alecto_wx500->rawlen-1;x+=2) {
+	for(x=1;x<alecto_wx500->rawlen;x+=2) {
 		if(alecto_wx500->raw[x] > AVG_PULSE) {
 			binary[i++] = 1;
 		} else {


### PR DESCRIPTION
There is a bug in the alecto_wx500 protocol I found by an analysis by valgrind.
RAWLENGTH is 74 and thus the binary array has a length of 37 but because of "rawlen-1" in the for loop bit 36 of the binary array is not set.
Because of this valgrind gives an "Conditional jump..." error in line 81 when this bit is used.
With this fix there were no valgrind errors for this protocol any more.