### PR TITLE
fix read beyond raw array in rsl366 protocol

### DIFF
--- a/libs/pilight/protocols/433.92/rsl366.c
+++ b/libs/pilight/protocols/433.92/rsl366.c
@@ -65,8 +65,8 @@ static void parseCode(void) {
 	int x = 0, i = 0, binary[RAW_LENGTH/4];
 
 	/* Convert the one's and zero's into binary */
-	for(x=0;x<rsl366->rawlen-1;x+=4) {
-		if(rsl366->raw[x+3] > (int)((double)AVG_PULSE_LENGTH*((double)PULSE_MULTIPLIER/2))) {
+	for(x=3;x<rsl366->rawlen;x+=4) {
+		if(rsl366->raw[x] > (int)((double)AVG_PULSE_LENGTH*((double)PULSE_MULTIPLIER/2))) {
 			binary[i++]=1;
 		} else {
 			binary[i++]=0;


### PR DESCRIPTION
There is a bug in the rsl366 protocol I found by an analysis by valgrind.
RAWLENGTH is 50 and thus rawlen-1 should be 49.
Thereby the for loop increments x until 48.
But then raw[x+3] will read beyond the raw array.
However, valgrind did not log invalid writes in line 70 or 72 which I cannot explain.
Perhaps someone with rsl366 hardware can test this fix.
I have no rsl366 hardware and, when I made the test, the event seemed to be triggered by RF noise.
With this fix there were no valgrind errors any more for this protocol.