### PR TITLE
Add config-option to receive even self-sent messages.

### DIFF
--- a/libs/pilight/config/settings.c
+++ b/libs/pilight/config/settings.c
@@ -528,6 +528,14 @@ static int settings_parse(JsonNode *root) {
 				settings_add_number(jsettings->key, (int)jsettings->number_);
 			}
 #endif //EVENTS
+		} else if(strcmp(jsettings->key, "receive-while-sending") == 0) {
+			if(jsettings->tag == JSON_NUMBER) {
+				settings_add_number(jsettings->key, (int)jsettings->number_);
+			} else {
+				logprintf(LOG_ERR, "config setting \"%s\" must be a number (0 disables, 1 enables)", jsettings->key);
+				have_error = 1;
+				goto clear;
+			}
 		} else {
 			logprintf(LOG_ERR, "config setting \"%s\" is invalid", jsettings->key);
 			have_error = 1;


### PR DESCRIPTION
The config option is at { "settings" : { "receive-while-sending": 0 or 1 } }
and the pilight-daemon is using it.  The purpose of this option is to test
protocol handler implementations like this:
Run pilight-receive at term one to see daemon logs. Then running a

  pilight-send -p proto --id xx --unit yy etc...

at term two should produce a sent and a receive message stating the same
id, unit and command codes. If they differ constantly the implementation
should be reviewed.

Note a strange thing: due to thread priorities, the receiving-log-message
may sometime appear before the send-log-message.
