### PR TITLE
telegram check added for arctech_switch_old protocol

### DIFF
--- a/libs/pilight/protocols/433.92/arctech_switch_old.c
+++ b/libs/pilight/protocols/433.92/arctech_switch_old.c
@@ -61,11 +61,30 @@ static void parseCode(void) {
 	int binary[RAW_LENGTH/4], x = 0, i = 0;
 	int len = (int)((double)AVG_PULSE_LENGTH*((double)PULSE_MULTIPLIER/2));
 
-	for(x=0;x<arctech_switch_old->rawlen-2;x+=4) {
+	for(x=0;x<arctech_switch_old->rawlen-3;x+=4) {
+		// valid telegrams must consist of 0110 and 1001 blocks
+		int low_high = 0;
+		if(arctech_switch_old->raw[x] > len) {
+			low_high |= 1;
+		}
+		if(arctech_switch_old->raw[x+1] > len) {
+			low_high |= 2;
+		}
+		if(arctech_switch_old->raw[x+2] > len) {
+			low_high |= 4;
+		}
 		if(arctech_switch_old->raw[x+3] > len) {
-			binary[i++] = 0;
-		} else {
-			binary[i++] = 1;
+			low_high |= 8;
+		}
+		switch(low_high) {
+			case 6:
+				binary[i++] = 1;
+			break;
+			case 10:
+				binary[i++] = 0;
+			break;
+			default:
+				return; // invalid telegram
 		}
 	}
 


### PR DESCRIPTION
I'm using remotes with the arctech_switch_old protocol and had often the problem that for example if I pushed an on button some of the telegrams send by the remote were recognized as off or even another id was recognized.
From the code it's clear that the telegrams can be divided in 4 bit parts which are either 1001 or 0110. When I analyzed the telegrams send by the remotes I noticed that the telegrams for which a wrong state or id was recognized did not match this scheme completely but the current parseCode function does only evaluate every fourth bit to distignuish between 1001 and 0110.
Thus by my pull request now all bits are evaluated and, if a 4 bit block does not match 1001 or 0110, the telegram is discarded.
With this change I no longer have the problem of wrongly recongized states or ids and the remotes are still working reliably.
