### PR TITLE
Support Freetech NC-7104-675, Globaltronics GT-WT-01

### DIFF
--- a/libs/pilight/protocols/433.92/tfa.c
+++ b/libs/pilight/protocols/433.92/tfa.c
@@ -32,10 +32,10 @@
 
 #define PULSE_MULTIPLIER	13
 #define MIN_PULSE_LENGTH	220
-#define MAX_PULSE_LENGTH	265
-#define AVG_PULSE_LENGTH	250
+#define MAX_PULSE_LENGTH	280	// FREETEC NC7104-675, Globaltronics GT-WT-01
+#define AVG_PULSE_LENGTH	235
 #define RAW_LENGTH			88
-#define MIN_RAW_LENGTH		76	// SOENS
+#define MIN_RAW_LENGTH		76	// SOENS, NC7104-675, GT-WT-01
 #define MED_RAW_LENGTH		86	// TFA
 #define MAX_RAW_LENGTH		88	// DOSTMAN 32.3200
 
@@ -246,6 +246,8 @@ void tfaInit(void) {
 	protocol_device_add(tfa, "tfa", "TFA weather stations");
 	protocol_device_add(tfa, "conrad_weather", "Conrad Weather Stations");
 	protocol_device_add(tfa, "soens", "SOENS Weather Stations");
+	protocol_device_add(tfa, "NC7104", "Freetec NC7104-675 Weather Station");
+	protocol_device_add(tfa, "GT-WT-01", "Globaltronics GT-WT-01 Weather Station");
 	tfa->devtype = WEATHER;
 	tfa->hwtype = RF433;
 	tfa->maxgaplen = MAX_PULSE_LENGTH*PULSE_DIV;
@@ -277,7 +279,7 @@ void tfaInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "tfa";
-	module->version = "1.2";
+	module->version = "1.3";
 	module->reqversion = "7.0";
 	module->reqcommit = "84";
 }


### PR DESCRIPTION
- Freetech NC-7104-675 (Soens with longer footer - 9050 range)
https://forum.pilight.org/Thread-Freetec-Temp-Humidity-Sensor?pid=16105#pid16105

- Globaltronics GT-WT-01 (Soens with longer footer 9050 range)
https://forum.pilight.org/Thread-Weather-Station-Globaltronics-GT-WT-01?pid=16234#pid16234

- Compatibility with 433USBnano (increase footer to 9300 range as reported in the forum link below)
https://forum.pilight.org/Thread-Freetec-Temp-Humidity-Sensor?pid=16105#pid16105

Pulse duration for binary decoding routine set back to original tfa protocol (bug fixing)