### PR TITLE
Fix segmentation fault code in ds18b20 driver

### DIFF
--- a/libs/pilight/protocols/GPIO/ds18b20.c
+++ b/libs/pilight/protocols/GPIO/ds18b20.c
@@ -225,7 +225,7 @@ static void *addDevice(void *param) {
 
 	json_find_number(jdevice, "temperature-offset", &node->temp_offset);
 
-	data->interval = interval;
+	node->interval = interval;
 
 	node->next = data;
 	data = node;


### PR DESCRIPTION
The value was assigned to a wrong and not yet allocated structure