### PR TITLE
Fix blank warning log messages

### DIFF
--- a/libs/pilight/core/log.c
+++ b/libs/pilight/core/log.c
@@ -142,11 +142,11 @@ void logprintf(int prio, const char *str, ...) {
 		
 		/* len + loglevel */
 		if(len+9 > bufsize) {
-			if((buffer = realloc(buffer, len+9+1)) == NULL) {
+			if((buffer = realloc(buffer, len+10)) == NULL) {
 				printf("out of memory\n");
 				exit(EXIT_FAILURE);
 			}
-			bufsize = len+9+1;
+			bufsize = len+10+1;
 		}
 		pos += snprintf(buffer, bufsize, "[%s:%03u] ", fmt, (unsigned int)tv.tv_usec);
 


### PR DESCRIPTION
These occurred for example when accessing an invalid page on the webserver (x.x.x.x:5000/conf for example)
Before:
```
[Jun 13 12:55:22:359922] WARNING:[Jun 13 12:55:22:567092] DEBUG: new client, ip: 127.0.0.1, port: 51047
```

After:
```
[Jun 13 13:19:55:969887] WARNING: (webserver) could not read /usr/local/share/pilight//conf
```