### PR TITLE
Various minor spelling fixes

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -945,7 +945,7 @@ static int socket_parse_responses(char *buffer, char *media, char **respons) {
 									json_delete(json);
 									return 0;
 								} else {
-									logprintf(LOG_ERR, "registry key '%s' doesn't exists", key);
+									logprintf(LOG_ERR, "registry key '%s' does not exist", key);
 									if((*respons = MALLOC(strlen("{\"status\":\"failed\"}")+1)) == NULL) {
 										OUT_OF_MEMORY
 									}
@@ -1231,7 +1231,7 @@ static void *socket_parse_data(void *param) {
 		json_delete(json);
 		return NULL;
 	} else {
-		logprintf(LOG_ERR, "could not parse respons to: %s", data->buffer);
+		logprintf(LOG_ERR, "could not parse response to: %s", data->buffer);
 		client_remove(sd);
 		socket_close(sd);
 		json_delete(json);
@@ -2363,7 +2363,7 @@ int start_pilight(int argc, char **argv) {
 									hardware->mingaplen = tmp->listener->mingaplen;
 								}
 								if(tmp->listener->rawlen > 0) {
-									logprintf(LOG_EMERG, "%s: setting \"rawlen\" length is not allowed, use the \"minrawlen\" and \"maxrawlen\" instead", tmp->listener->id);
+									logprintf(LOG_EMERG, "%s: setting \"rawlen\" length is not allowed, use \"minrawlen\" and \"maxrawlen\" instead", tmp->listener->id);
 									goto clear;
 								}
 							}

--- a/flash.c
+++ b/flash.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
 					fwfile = REALLOC(fwfile, strlen(args)+1);
 					strcpy(fwfile, args);
 				} else {
-					fprintf(stderr, "%s: the firmware file %s does not exists\n", progname, args);
+					fprintf(stderr, "%s: the firmware file %s does not exist\n", progname, args);
 					goto close;
 				}
 			break;

--- a/libs/pilight/core/arp.c
+++ b/libs/pilight/core/arp.c
@@ -376,7 +376,7 @@ int arp_resolv(struct arp_list_t *iplist, char *if_name, char *srcmac, char *dst
 		pcap_freealldevs(alldevs);
 	}
 	if(match == 0) {
-		logprintf(LOG_ERR, "could not full interface name for %s", if_name);
+		logprintf(LOG_ERR, "could not find interface name for %s", if_name);
 		FREE(if_cpy);
 		return -1;
 	}

--- a/libs/pilight/core/datetime.c
+++ b/libs/pilight/core/datetime.c
@@ -475,7 +475,7 @@ void datetime_init(void) {
 
 int datetime_gc(void) {
 /*
-	Extra checks for gracefull (early)
+	Extra checks for graceful (early)
   stopping of pilight
 */
 	if(mutex_init == 1) {
@@ -491,7 +491,7 @@ int datetime_gc(void) {
 char *coord2tz(double longitude, double latitude) {
 
 /*
-	Extra checks for gracefull (early)
+	Extra checks for graceful (early)
   stopping of pilight
 */
 	if(mutex_init == 1) {

--- a/libs/pilight/core/firmware.c
+++ b/libs/pilight/core/firmware.c
@@ -1138,7 +1138,7 @@ int firmware_getmp(char *port) {
 	struct avrpart *p = NULL;
 	unsigned int match = 0;
 
-	logprintf(LOG_INFO, "Indentifying microprocessor");
+	logprintf(LOG_INFO, "Identifying microprocessor");
 	/*
 	mptype = FW_MP_ATMEL32U4;
 	firmware_atmega32u4(&p);

--- a/libs/pilight/core/http.c
+++ b/libs/pilight/core/http.c
@@ -84,11 +84,11 @@ static int prepare_request(struct request_t **request, int method, char *url, co
 		(*request)->port = 443;
 		plen = 9;
 		if(ssl_client_init_status() == -1) {
-			logprintf(LOG_ERR, "https url's require a properly initialized ssl library");
+			logprintf(LOG_ERR, "HTTPS URL's require a properly initialized SSL library");
 			return -1;
 		}
 	} else {
-		logprintf(LOG_ERR, "an url should start with either http:// or https://");
+		logprintf(LOG_ERR, "A URL should start with either http:// or https://");
 		FREE((*request));
 		return -1;
 	}
@@ -161,7 +161,7 @@ static void append_to_header(char **header, char *data, ...) {
 	bytes = vsnprintf(NULL, 0, data, apcpy);
 #endif
 	if(bytes == -1) {
-		fprintf(stderr, "ERROR: unproperly formatted logprintf message %s\n", data);
+		fprintf(stderr, "ERROR: improperly formatted logprintf message %s\n", data);
 	} else {
 		va_end(apcpy);
 		if((*header = REALLOC(*header, pos+bytes+1)) == NULL) {

--- a/libs/pilight/core/log.c
+++ b/libs/pilight/core/log.c
@@ -178,7 +178,7 @@ void logprintf(int prio, const char *str, ...) {
 		len = vsnprintf(NULL, 0, str, apcpy);
 #endif
 		if(len == -1) {
-			fprintf(stderr, "ERROR: unproperly formatted logprintf message %s\n", str);
+			fprintf(stderr, "ERROR: improperly formatted logprintf message %s\n", str);
 		} else {
 			va_end(apcpy);
 			if(len+pos+3 > bufsize) {

--- a/libs/pilight/core/mail.c
+++ b/libs/pilight/core/mail.c
@@ -584,7 +584,7 @@ int sendmail(char *host, char *login, char *pass, unsigned short port, struct ma
 			request->is_ssl = 0;
 		break;
 		default:
-			logprintf(LOG_ERR, "port %d is not an valid SMTP port", port);
+			logprintf(LOG_ERR, "port %d is not a valid SMTP port", port);
 			FREE(request);
 			if(request->callback != NULL) {
 				request->callback(-1);
@@ -593,7 +593,7 @@ int sendmail(char *host, char *login, char *pass, unsigned short port, struct ma
 		break;
 	}
 	if(request->is_ssl == 1 && ssl_client_init_status() == -1) {
-		logprintf(LOG_ERR, "secure mails require a properly initialized ssl library");
+		logprintf(LOG_ERR, "secure e-mails require a properly initialized SSL library");
 		FREE(request);
 		if(request->callback != NULL) {
 			request->callback(-1);

--- a/libs/pilight/core/options.c
+++ b/libs/pilight/core/options.c
@@ -334,9 +334,9 @@ int options_parse(struct options_t **opt, int argc, char **argv, int error_check
 		} else if(strlen(*optarg) != 0 && options_get_argtype(opt, c, &itmp) == 0 && itmp == 1) {
 			if(error_check == 1) {
 				if(strcmp(longarg,shortarg) == 0) {
-					logprintf(LOG_ERR, "option '-%c' doesn't take an argument", c);
+					logprintf(LOG_ERR, "option '-%c' does not take an argument", c);
 				} else {
-					logprintf(LOG_ERR, "option '%s' doesn't take an argument", longarg);
+					logprintf(LOG_ERR, "option '%s' does not take an argument", longarg);
 				}
 				goto gc;
 			} else {

--- a/libs/pilight/core/sha256cache.c
+++ b/libs/pilight/core/sha256cache.c
@@ -66,7 +66,7 @@ int sha256cache_rm(char *name) {
 }
 
 int sha256cache_add(char *name) {
-	logprintf(LOG_INFO, "chached new sha256 hash");
+	logprintf(LOG_INFO, "cached new sha256 hash");
 
 	unsigned char output[33];
 	char *password = NULL;

--- a/libs/pilight/core/socket.c
+++ b/libs/pilight/core/socket.c
@@ -166,7 +166,7 @@ static int server_callback(struct eventpool_fd_t *node, int event) {
 				perror("getsockname");
 			} else {
 				socket_port = ntohs(servaddr.sin_port);
-				logprintf(LOG_INFO, "daemon listening to port: %d", socket_port);
+				logprintf(LOG_INFO, "daemon listening on port: %d", socket_port);
 			}
 		} break;
 		case EV_READ: {
@@ -471,7 +471,7 @@ int socket_read(int sockfd, char **message, time_t timeout) {
 		if(timeout > 0 && n == 0) {
 			return 1;
 		}
-		/* Immediatly stop loop if the select was waken up by the garbage collector */
+		/* Immediately stop loop if the select was waken up by the garbage collector */
 		if(socket_loop == 0) {
 			break;
 		}

--- a/libs/pilight/core/ssdp.c
+++ b/libs/pilight/core/ssdp.c
@@ -283,7 +283,7 @@ static int client_callback(struct eventpool_fd_t *node, int event) {
 			addr.sin_addr.s_addr = inet_addr("239.255.255.250");
 
 			if(sendto(node->fd, header, BUFFER_SIZE, 0, (struct sockaddr *)&addr, sizeof(addr)) >= 0) {
-				logprintf(LOG_DEBUG, "ssdp sent search");
+				logprintf(LOG_DEBUG, "ssdp search sent");
 			}
 			eventpool_fd_enable_read(node);
 		} break;

--- a/libs/pilight/core/webserver.c
+++ b/libs/pilight/core/webserver.c
@@ -414,7 +414,7 @@ static int parse_rest(struct connection_t *conn) {
 					} else if(strcmp(array1[0], "device") == 0) {
 						dev = array1[1];
 						if(devices_select(ORIGIN_WEBSERVER, array1[1], NULL) != 0) {
-							char *z = "{\"message\":\"failed\",\"error\":\"device does not exists\"}";
+							char *z = "{\"message\":\"failed\",\"error\":\"device does not exist\"}";
 							send_data(conn, z, strlen(z));
 							goto clear;
 						}
@@ -440,7 +440,7 @@ static int parse_rest(struct connection_t *conn) {
 			}
 			if(type == 0) {
 				if(has_protocol == 0) {
-					char *z = "{\"message\":\"failed\",\"error\":\"no protocol was send\"}";
+					char *z = "{\"message\":\"failed\",\"error\":\"no protocol was sent\"}";
 					send_data(conn, z, strlen(z));
 					goto clear;
 				}
@@ -454,7 +454,7 @@ static int parse_rest(struct connection_t *conn) {
 			} else if(type == 1) {
 				if(pilight.control != NULL) {
 					if(dev == NULL) {
-						char *z = "{\"message\":\"failed\",\"error\":\"no device was send\"}";
+						char *z = "{\"message\":\"failed\",\"error\":\"no device was sent\"}";
 						send_data(conn, z, strlen(z));
 						goto clear;
 					} else {

--- a/libs/pilight/events/actions/dim.c
+++ b/libs/pilight/events/actions/dim.c
@@ -176,7 +176,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 							if(strcmp(array[1], units[i].name) == 0) {
 								match = 1;
 								if(isNumeric(array[0]) != 0 && atoi(array[0]) <= 0) {
-									logprintf(LOG_ERR, "switch action \"FOR\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+									logprintf(LOG_ERR, "dim action \"FOR\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 									array_free(&array, l);
 									return -1;
 								}
@@ -184,13 +184,13 @@ static int checkArguments(struct rules_actions_t *obj) {
 							}
 						}
 						if(match == 0) {
-							logprintf(LOG_ERR, "switch action \"%s\" is not a valid unit", array[1]);
+							logprintf(LOG_ERR, "dim action \"%s\" is not a valid unit", array[1]);
 							array_free(&array, l);
 							return -1;
 						}
 						array_free(&array, l);
 					} else {
-						logprintf(LOG_ERR, "switch action \"FOR\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+						logprintf(LOG_ERR, "dim action \"FOR\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 						if(l > 0) {
 							array_free(&array, l);
 						}
@@ -220,7 +220,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 							if(strcmp(array[1], units[i].name) == 0) {
 								match = 1;
 								if(isNumeric(array[0]) != 0 && atoi(array[0]) <= 0) {
-									logprintf(LOG_ERR, "switch action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+									logprintf(LOG_ERR, "dim action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 									array_free(&array, l);
 									return -1;
 								}
@@ -228,13 +228,13 @@ static int checkArguments(struct rules_actions_t *obj) {
 							}
 						}
 						if(match == 0) {
-							logprintf(LOG_ERR, "switch action \"%s\" is not a valid unit", array[1]);
+							logprintf(LOG_ERR, "dim action \"%s\" is not a valid unit", array[1]);
 							array_free(&array, l);
 							return -1;
 						}
 						array_free(&array, l);
 					} else {
-						logprintf(LOG_ERR, "switch action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+						logprintf(LOG_ERR, "dim action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 						if(l > 0) {
 							array_free(&array, l);
 						}
@@ -279,7 +279,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 							if(strcmp(array[1], units[i].name) == 0) {
 								match = 1;
 								if(isNumeric(array[0]) != 0 && atoi(array[0]) <= 0) {
-									logprintf(LOG_ERR, "switch action \"IN\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+									logprintf(LOG_ERR, "dim action \"IN\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 									array_free(&array, l);
 									return -1;
 								}
@@ -287,13 +287,13 @@ static int checkArguments(struct rules_actions_t *obj) {
 							}
 						}
 						if(match == 0) {
-							logprintf(LOG_ERR, "switch action \"%s\" is not a valid unit", array[1]);
+							logprintf(LOG_ERR, "dim action \"%s\" is not a valid unit", array[1]);
 							array_free(&array, l);
 							return -1;
 						}
 						array_free(&array, l);
 					} else {
-						logprintf(LOG_ERR, "switch action \"IN\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+						logprintf(LOG_ERR, "dim action \"IN\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 						if(l > 0) {
 							array_free(&array, l);
 						}
@@ -330,14 +330,14 @@ static int checkArguments(struct rules_actions_t *obj) {
 									while(devices_select_settings(ORIGIN_ACTION, jbchild->string_, i++, &setting, &val) == 0) {
 										if(strcmp(setting, "dimlevel-maximum") == 0 && val.type_ == JSON_NUMBER) {
 											if((int)val.number_ < dimto) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
 												return -1;
 											}
 											match1 = 1;
 										}
 										if(strcmp(setting, "dimlevel-minimum") == 0 && val.type_ == JSON_NUMBER) {
 											if((int)val.number_ > dimto) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
 												return -1;
 											}
 											match2 = 1;
@@ -348,19 +348,19 @@ static int checkArguments(struct rules_actions_t *obj) {
 										while(opt) {
 											if(match1 == 0 && strcmp(opt->name, "dimlevel-maximum") == 0 &&
 												opt->vartype == JSON_NUMBER && (int)(intptr_t)opt->def < (int)dimto) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
 												return -1;
 											}
 											if(match2 == 0 && strcmp(opt->name, "dimlevel-minimum") == 0 &&
 												opt->vartype == JSON_NUMBER && (int)(intptr_t)opt->def > (int)dimto) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimto);
 												return -1;
 											}
 											opt = opt->next;
 										}
 									}
 								} else {
-									logprintf(LOG_ERR, "device \"%s\" doesn't support dimming", jbchild->string_);
+									logprintf(LOG_ERR, "device \"%s\" does not support dimming", jbchild->string_);
 									return -1;
 								}
 							}
@@ -389,14 +389,14 @@ static int checkArguments(struct rules_actions_t *obj) {
 									while(devices_select_settings(ORIGIN_ACTION, jbchild->string_, i++, &setting, &val) == 0) {
 										if(strcmp(setting, "dimlevel-maximum") == 0 && val.type_ == JSON_NUMBER) {
 											if((int)val.number_ < dimfrom) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
 												return -1;
 											}
 											match1 = 1;
 										}
 										if(strcmp(setting, "dimlevel-minimum") == 0 && val.type_ == JSON_NUMBER) {
 											if((int)val.number_ > dimfrom) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
 												return -1;
 											}
 											match2 = 1;
@@ -407,24 +407,24 @@ static int checkArguments(struct rules_actions_t *obj) {
 										while(opt) {
 											if(match1 == 0 && strcmp(opt->name, "dimlevel-maximum") == 0 &&
 											opt->vartype == JSON_NUMBER && (int)(intptr_t)opt->def < (int)dimfrom) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
 												return -1;
 											}
 											if(match2 == 0 && strcmp(opt->name, "dimlevel-minimum") == 0 &&
 											opt->vartype == JSON_NUMBER && (int)(intptr_t)opt->def > (int)dimfrom) {
-												logprintf(LOG_ERR, "device \"%s\" can't be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
+												logprintf(LOG_ERR, "device \"%s\" cannot be set to dimlevel \"%d\"", jbchild->string_, (int)dimfrom);
 												return -1;
 											}
 											opt = opt->next;
 										}
 									}
 								} else {
-									logprintf(LOG_ERR, "device \"%s\" doesn't support dimming", jbchild->string_);
+									logprintf(LOG_ERR, "device \"%s\" does not support dimming", jbchild->string_);
 									return -1;
 								}
 							}
 						} else {
-							logprintf(LOG_ERR, "device \"%s\" doesn't exists", jbchild->string_);
+							logprintf(LOG_ERR, "device \"%s\" does not exist", jbchild->string_);
 							return -1;
 						}
 						jechild = jechild->next;
@@ -885,7 +885,7 @@ void actionDimInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "dim";
-	module->version = "4.0";
+	module->version = "4.0.1";
 	module->reqversion = "7.0";
 	module->reqcommit = "94";
 }

--- a/libs/pilight/events/actions/label.c
+++ b/libs/pilight/events/actions/label.c
@@ -163,13 +163,13 @@ static int checkArguments(struct rules_actions_t *obj) {
 							}
 						}
 						if(match == 0) {
-							logprintf(LOG_ERR, "switch action \"%s\" is not a valid unit", array[1]);
+							logprintf(LOG_ERR, "label action \"%s\" is not a valid unit", array[1]);
 							array_free(&array, l);
 							return -1;
 						}
 						array_free(&array, l);
 					} else {
-						logprintf(LOG_ERR, "switch action \"FOR\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+						logprintf(LOG_ERR, "label action \"FOR\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 						if(l > 0) {
 							array_free(&array, l);
 						}
@@ -199,7 +199,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 							if(strcmp(array[1], units[i].name) == 0) {
 								match = 1;
 								if(isNumeric(array[0]) != 0) {
-									logprintf(LOG_ERR, "switch action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+									logprintf(LOG_ERR, "label action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 									array_free(&array, l);
 									return -1;
 								}
@@ -207,13 +207,13 @@ static int checkArguments(struct rules_actions_t *obj) {
 							}
 						}
 						if(match == 0) {
-							logprintf(LOG_ERR, "switch action \"%s\" is not a valid unit", array[1]);
+							logprintf(LOG_ERR, "label action \"%s\" is not a valid unit", array[1]);
 							array_free(&array, l);
 							return -1;
 						}
 						array_free(&array, l);
 					} else {
-						logprintf(LOG_ERR, "switch action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
+						logprintf(LOG_ERR, "label action \"AFTER\" requires a positive number and a unit e.g. \"1 MINUTE\"");
 						if(l > 0) {
 							array_free(&array, l);
 						}
@@ -257,11 +257,11 @@ static int checkArguments(struct rules_actions_t *obj) {
 						}
 					}
 					if(match == 0) {
-						logprintf(LOG_ERR, "the label action only works with the label devices");
+						logprintf(LOG_ERR, "the label action only works with label devices");
 						return -1;
 					}
 				} else {
-					logprintf(LOG_ERR, "device \"%s\" doesn't exists", jbchild->string_);
+					logprintf(LOG_ERR, "device \"%s\" does not exist", jbchild->string_);
 					return -1;
 				}
 			} else {
@@ -291,7 +291,7 @@ static void *execute(void *param) {
 	}
 
 	if(strcmp(data->old_label, data->new_label) == 0 && data->new_color != NULL && strcmp(data->old_color, data->new_color) == 0) {
-		logprintf(LOG_DEBUG, "device \"%s\" is already labeled \"%s\" with color \"%s\", aborting action \"%s\"", data->device, data->new_label, data->new_color, action_label->name);
+		logprintf(LOG_DEBUG, "device \"%s\" is already labelled \"%s\" with color \"%s\", aborting action \"%s\"", data->device, data->new_label, data->new_color, action_label->name);
 		data->steps = -1;
 	}
 	switch(data->steps) {
@@ -690,7 +690,7 @@ void actionLabelInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "label";
-	module->version = "3.0";
+	module->version = "3.0.1";
 	module->reqversion = "7.0";
 	module->reqcommit = "94";
 }

--- a/libs/pilight/events/actions/sendmail.c
+++ b/libs/pilight/events/actions/sendmail.c
@@ -151,7 +151,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 
 static void callback(int status) {
 	if(status == 0) {
-		logprintf(LOG_INFO, "successfully send sendmail action message");
+		logprintf(LOG_INFO, "successfully sent sendmail action message");
 	} else {
 		logprintf(LOG_INFO, "failed to send sendmail action message");
 	}
@@ -259,7 +259,7 @@ void actionSendmailInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "sendmail";
-	module->version = "2.0";
+	module->version = "2.0.1";
 	module->reqversion = "7.0";
 	module->reqcommit = "94";
 }

--- a/libs/pilight/events/actions/switch.c
+++ b/libs/pilight/events/actions/switch.c
@@ -237,7 +237,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 									}
 								}
 								if(match1 == 0) {
-									logprintf(LOG_ERR, "device \"%s\" can't be set to state \"%s\"", jbchild->string_, state);
+									logprintf(LOG_ERR, "device \"%s\" cannot be set to state \"%s\"", jbchild->string_, state);
 									return -1;
 								}
 							} else {
@@ -249,7 +249,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 						return -1;
 					}
 				} else {
-					logprintf(LOG_ERR, "device \"%s\" doesn't exists", jbchild->string_);
+					logprintf(LOG_ERR, "device \"%s\" does not exist", jbchild->string_);
 					return -1;
 				}
 			} else {
@@ -543,7 +543,7 @@ void actionSwitchInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "switch";
-	module->version = "4.0";
+	module->version = "4.0.1";
 	module->reqversion = "7.0";
 	module->reqcommit = "94";
 }

--- a/libs/pilight/events/actions/toggle.c
+++ b/libs/pilight/events/actions/toggle.c
@@ -86,7 +86,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 									}
 								}
 								if(match1 == 0) {
-									logprintf(LOG_ERR, "device \"%s\" can't be set to state \"%s\"", jdchild->string_, jschild->string_);
+									logprintf(LOG_ERR, "device \"%s\" cannot be set to state \"%s\"", jdchild->string_, jschild->string_);
 									return -1;
 								}
 							} else {
@@ -96,7 +96,7 @@ static int checkArguments(struct rules_actions_t *obj) {
 						}
 					}
 				} else {
-					logprintf(LOG_ERR, "device \"%s\" doesn't exists", jdchild->string_);
+					logprintf(LOG_ERR, "device \"%s\" does not exist", jdchild->string_);
 					return -1;
 				}
 			} else {
@@ -196,7 +196,7 @@ void actionToggleInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "toggle";
-	module->version = "3.0";
+	module->version = "3.0.1";
 	module->reqversion = "7.0";
 	module->reqcommit = "94";
 }

--- a/libs/pilight/events/events.c
+++ b/libs/pilight/events/events.c
@@ -918,7 +918,7 @@ static int event_parse_formula(char **rule, struct rules_t *obj, int depth, unsi
 						unsigned long r = 0;
 						// printf("replace %s with %s in %s\n", search, p, tmp);
 						if((r = (unsigned long)str_replace(search, p, &tmp)) == -1) {
-							logprintf(LOG_ERR, "rule #%d: an unexpected error occured while parsing", obj->nr);
+							logprintf(LOG_ERR, "rule #%d: an unexpected error occurred while parsing", obj->nr);
 							FREE(p);
 							error = -1;
 							goto close;
@@ -1147,7 +1147,7 @@ static int event_parse_action(char *action, struct rules_t *obj, int validate) {
 		}
 
 		if(match == 0) {
-			logprintf(LOG_ERR, "action \"%s\" doesn't exists", func);
+			logprintf(LOG_ERR, "action \"%s\" does not exist", func);
 			error = 1;
 			break;
 		}
@@ -1344,7 +1344,7 @@ static int event_parse_action(char *action, struct rules_t *obj, int validate) {
 								opt = opt->next;
 							}
 							if(match == 0) {
-								logprintf(LOG_ERR, "action \"%s\" doesn't accept option \"%s\"", node->action->name, jchild->key);
+								logprintf(LOG_ERR, "action \"%s\" does not accept option \"%s\"", node->action->name, jchild->key);
 								error = 1;
 								break;
 							}

--- a/libs/pilight/hardware/zwave.cpp
+++ b/libs/pilight/hardware/zwave.cpp
@@ -558,7 +558,7 @@ static void OnDeviceStatusUpdate(OpenZWave::Driver::ControllerState cs, OpenZWav
 			logprintf(LOG_INFO, "[Z-Wave]: Starting controller command");
 		break;
 		case OpenZWave::Driver::ControllerState_Cancel:
-			logprintf(LOG_INFO, "[Z-Wave]: The command was canceled");
+			logprintf(LOG_INFO, "[Z-Wave]: The command was cancelled");
 			pending_command = 0;
 		break;
 		case OpenZWave::Driver::ControllerState_Error:
@@ -695,7 +695,7 @@ void zwaveInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "zwave";
-	module->version = "2.0";
+	module->version = "2.0.1";
 	module->reqversion = "8.0";
 	module->reqcommit = NULL;
 }

--- a/libs/pilight/storage/storage.c
+++ b/libs/pilight/storage/storage.c
@@ -953,7 +953,7 @@ int devices_validate_id(struct JsonNode *jdevices, int i) {
 		if((x-1) != valid_values) {
 			if(etype == 1) {
 				if(i > 0) {
-					logprintf(LOG_ERR, "protocol \"%s\" used in \"%s\" doesn't support multiple id's", protocol->id, jdevices->key);
+					logprintf(LOG_ERR, "protocol \"%s\" used in \"%s\" does not support multiple id's", protocol->id, jdevices->key);
 				}
 			} else {
 				if(i > 0) {

--- a/send.c
+++ b/send.c
@@ -440,7 +440,7 @@ int main(int argc, char **argv) {
 			}
 			/* If no protocols matches the requested protocol */
 			if(match == 0) {
-				logprintf(LOG_ERR, "this protocol is not supported or doesn't support sending");
+				logprintf(LOG_ERR, "this protocol is not supported or does not support sending");
 				goto close;
 			}
 		}


### PR DESCRIPTION
Fix several minor spelling/copy-paste errors.

arp.c: clarify error message
datetime.c: fix spelling
firmware.c: fix spelling
http.c: fix error messages
log.c: fix spelling
mail.c: fix error messages
options.c: fix spelling
sha256chache.c: fix spelling
socket.c: fix log message and spelling
ssdp.c: fix log message
webserver.c: fix spelling in log messages and REST error messages
events.c: fix spelling
dim.c: fix spelling, remove contractions, fix copy-paste errors
label.c: fix spelling, remove contractions, fix copy-paste errors
sendmail.c: fix spelling
switch.c: fix spelling, remove contractions, fix copy-paste errors
toggle.c: fix spelling, remove contractions
zwave.cpp: fix spelling
storage.c: fix spelling
daemon.c: fix spelling in log messages
flash.c: fix spelling
send.c: remove contraction