### PR TITLE
add support for pushsafer.com notification service

### DIFF
--- a/libs/pilight/events/actions/pushsafer.c
+++ b/libs/pilight/events/actions/pushsafer.c
@@ -1,0 +1,311 @@
+/*
+	Copyright (C) 2013 - 2014 CurlyMo
+	
+	Copyright (C) 2016 Pushsafer.com Kevin Siml > Appzer.de
+
+	This file is part of pilight.
+
+	pilight is free software: you can redistribute it and/or modify it under the
+	terms of the GNU General Public License as published by the Free Software
+	Foundation, either version 3 of the License, or (at your option) any later
+	version.
+
+	pilight is distributed in the hope that it will be useful, but WITHOUT ANY
+	WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+	A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with pilight. If not, see	<http://www.gnu.org/licenses/>
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../../core/threads.h"
+#include "../action.h"
+#include "../../core/options.h"
+#include "../../config/devices.h"
+#include "../../core/log.h"
+#include "../../core/dso.h"
+#include "../../core/pilight.h"
+#include "../../core/http.h"
+#include "../../core/common.h"
+#include "pushsafer.h"
+
+static int checkArguments(struct rules_actions_t *obj) {
+	struct JsonNode *jtitle = NULL;
+	struct JsonNode *jmessage = NULL;
+	struct JsonNode *jdevice = NULL;
+	struct JsonNode *jicon = NULL;
+	struct JsonNode *jsound = NULL;
+	struct JsonNode *jvibration = NULL;
+	struct JsonNode *jprivatekey = NULL;
+	struct JsonNode *jvalues = NULL;
+	struct JsonNode *jchild = NULL;
+	int nrvalues = 0;
+
+	jtitle = json_find_member(obj->arguments, "TITLE");
+	jmessage = json_find_member(obj->arguments, "MESSAGE");
+	jprivatekey = json_find_member(obj->arguments, "PRIVATEKEY");
+	jdevice = json_find_member(obj->arguments, "DEVICE");
+	jicon = json_find_member(obj->arguments, "ICON");
+	jsound = json_find_member(obj->arguments, "SOUND");
+	jvibration = json_find_member(obj->arguments, "VIBRATION");
+
+	if(jtitle == NULL) {
+		logprintf(LOG_ERR, "pushsafer action is missing a \"TITLE\"");
+		return -1;
+	}
+	if(jmessage == NULL) {
+		logprintf(LOG_ERR, "pushsafer action is missing a \"MESSAGE\"");
+		return -1;
+	}
+	if(jdevice == NULL) {
+		logprintf(LOG_ERR, "pushsafer action is missing a \"DEVICE\"");
+		return -1;
+	}
+	if(jicon == NULL) {
+		logprintf(LOG_ERR, "pushsafer action is missing a \"ICON\"");
+		return -1;
+	}
+	if(jsound == NULL) {
+		logprintf(LOG_ERR, "pushsafer action is missing a \"SOUND\"");
+		return -1;
+	}
+	if(jvibration == NULL) {
+		logprintf(LOG_ERR, "pushsafer action is missing a \"VIBRATION\"");
+		return -1;
+	}	
+	if(jprivatekey == NULL) {
+		logprintf(LOG_ERR, "pushsafer action is missing a \"PRIVATEKEY\"");
+		return -1;
+	}
+	nrvalues = 0;
+	if((jvalues = json_find_member(jtitle, "value")) != NULL) {
+		jchild = json_first_child(jvalues);
+		while(jchild) {
+			nrvalues++;
+			jchild = jchild->next;
+		}
+	}
+	if(nrvalues != 1) {
+		logprintf(LOG_ERR, "pushsafer action \"TITLE\" only takes one argument");
+		return -1;
+	}
+	nrvalues = 0;
+	if((jvalues = json_find_member(jmessage, "value")) != NULL) {
+		jchild = json_first_child(jvalues);
+		while(jchild) {
+			nrvalues++;
+			jchild = jchild->next;
+		}
+	}
+	if(nrvalues != 1) {
+		logprintf(LOG_ERR, "pushsafer action \"MESSAGE\" only takes one argument");
+		return -1;
+	}
+	nrvalues = 0;
+	if((jvalues = json_find_member(jprivatekey, "value")) != NULL) {
+		jchild = json_first_child(jvalues);
+		while(jchild) {
+			nrvalues++;
+			jchild = jchild->next;
+		}
+	}
+	if(nrvalues != 1) {
+		logprintf(LOG_ERR, "pushsafer action \"PRIVATEKEY\" only takes one argument");
+		return -1;
+	}
+	nrvalues = 0;
+	if((jvalues = json_find_member(jdevice, "value")) != NULL) {
+		jchild = json_first_child(jvalues);
+		while(jchild) {
+			nrvalues++;
+			jchild = jchild->next;
+		}
+	}
+	if(nrvalues != 1) {
+		logprintf(LOG_ERR, "pushsafer action \"DEVICE\" only takes one argument");
+		return -1;
+	}
+	nrvalues = 0;
+	if((jvalues = json_find_member(jicon, "value")) != NULL) {
+		jchild = json_first_child(jvalues);
+		while(jchild) {
+			nrvalues++;
+			jchild = jchild->next;
+		}
+	}
+	if(nrvalues != 1) {
+		logprintf(LOG_ERR, "pushsafer action \"ICON\" only takes one argument");
+		return -1;
+	}
+	nrvalues = 0;
+	if((jvalues = json_find_member(jsound, "value")) != NULL) {
+		jchild = json_first_child(jvalues);
+		while(jchild) {
+			nrvalues++;
+			jchild = jchild->next;
+		}
+	}
+	if(nrvalues != 1) {
+		logprintf(LOG_ERR, "pushsafer action \"SOUND\" only takes one argument");
+		return -1;
+	}
+	nrvalues = 0;
+	if((jvalues = json_find_member(jvibration, "value")) != NULL) {
+		jchild = json_first_child(jvalues);
+		while(jchild) {
+			nrvalues++;
+			jchild = jchild->next;
+		}
+	}
+	if(nrvalues != 1) {
+		logprintf(LOG_ERR, "pushsafer action \"VIBRATION\" only takes one argument");
+		return -1;
+	}	
+	return 0;
+}
+
+static void *thread(void *param) {
+	struct rules_actions_t *pth = (struct rules_actions_t *)param;
+	// struct rules_t *obj = pth->obj;
+	struct JsonNode *arguments = pth->parsedargs;
+	struct JsonNode *jtitle = NULL;
+	struct JsonNode *jmessage = NULL;
+	struct JsonNode *jdevice = NULL;
+	struct JsonNode *jicon = NULL;
+	struct JsonNode *jsound = NULL;
+	struct JsonNode *jvibration = NULL;
+	struct JsonNode *jprivatekey = NULL;
+	struct JsonNode *jvalues1 = NULL;
+	struct JsonNode *jvalues2 = NULL;
+	struct JsonNode *jvalues3 = NULL;
+	struct JsonNode *jvalues4 = NULL;
+	struct JsonNode *jvalues5 = NULL;
+	struct JsonNode *jvalues6 = NULL;
+	struct JsonNode *jvalues7 = NULL;
+	struct JsonNode *jval1 = NULL;
+	struct JsonNode *jval2 = NULL;
+	struct JsonNode *jval3 = NULL;
+	struct JsonNode *jval4 = NULL;
+	struct JsonNode *jval5 = NULL;
+	struct JsonNode *jval6 = NULL;
+	struct JsonNode *jval7 = NULL;
+
+	action_pushsafer->nrthreads++;
+
+	char url[1024], typebuf[70];
+	char *data = NULL, *tp = typebuf;
+	int ret = 0, size = 0;
+
+	jtitle = json_find_member(arguments, "TITLE");
+	jmessage = json_find_member(arguments, "MESSAGE");
+	jprivatekey = json_find_member(arguments, "PRIVATEKEY");
+	jdevice = json_find_member(arguments, "DEVICE");
+	jicon = json_find_member(arguments, "ICON");
+	jsound = json_find_member(arguments, "SOUND");
+	jvibration = json_find_member(arguments, "VIBRATION");
+
+	if(jtitle != NULL && jmessage != NULL && jprivatekey != NULL && jdevice != NULL && jicon != NULL && jsound != NULL && jvibration != NULL) {
+		jvalues1 = json_find_member(jtitle, "value");
+		jvalues2 = json_find_member(jmessage, "value");
+		jvalues3 = json_find_member(jprivatekey, "value");
+		jvalues4 = json_find_member(jdevice, "value");
+		jvalues5 = json_find_member(jicon, "value");
+		jvalues6 = json_find_member(jsound, "value");
+		jvalues7 = json_find_member(jvibration, "value");
+		if(jvalues1 != NULL && jvalues2 != NULL && jvalues3 != NULL && jvalues4 != NULL && jvalues5 != NULL && jvalues6 != NULL && jvalues7 != NULL) {
+			jval1 = json_find_element(jvalues1, 0);
+			jval2 = json_find_element(jvalues2, 0);
+			jval3 = json_find_element(jvalues3, 0);
+			jval4 = json_find_element(jvalues4, 0);
+			jval5 = json_find_element(jvalues5, 0);
+			jval6 = json_find_element(jvalues6, 0);
+			jval7 = json_find_element(jvalues7, 0);
+			if(jval1 != NULL && jval2 != NULL && jval3 != NULL && jval4 != NULL && jval5 != NULL && jval6 != NULL && jval7 != NULL &&
+			 jval1->tag == JSON_STRING && jval2->tag == JSON_STRING &&
+			 jval3->tag == JSON_STRING && jval4->tag == JSON_STRING &&
+			 jval5->tag == JSON_STRING && jval6->tag == JSON_STRING &&
+			 jval7->tag == JSON_STRING) {
+				data = NULL;
+				strcpy(url, "https://www.pushsafer.com/api");
+				char *message = urlencode(jval2->string_);
+				char *privatekey = urlencode(jval3->string_);
+				char *device = urlencode(jval4->string_);
+				char *icon = urlencode(jval5->string_);
+				char *sound = urlencode(jval6->string_);
+				char *vibration = urlencode(jval7->string_);
+				char *title = urlencode(jval1->string_);
+				size_t l = strlen(message)+strlen(privatekey);
+				l += strlen(device)+strlen(title);
+				l += strlen(icon)+strlen(sound)+strlen(vibration);
+				l += strlen("k=")+strlen("&d=");
+				l += strlen("&m=")+strlen("&t=");
+				l += strlen("&i=")+strlen("&s=")+strlen("&v=");
+				char content[l+2];
+				sprintf(content, "k=%s&d=%s&i=%s&s=%s&v=%s&t=%s&m=%s", privatekey, device, icon, sound, vibration, title, message);
+				data = http_post_content(url, &tp, &ret, &size, "application/x-www-form-urlencoded", content);
+				if(ret == 200) {
+					logprintf(LOG_DEBUG, "pushsafer action succeeded with message: %s", data);
+				} else {
+					logprintf(LOG_NOTICE, "pushsafer action failed (%d) with message: %s", ret, data);
+				}
+				FREE(message);
+				FREE(privatekey);
+				FREE(device);
+				FREE(icon);
+				FREE(sound);
+				FREE(vibration);
+				FREE(title);
+				if(data != NULL) {
+					FREE(data);
+				}
+			}
+		}
+	}
+
+	action_pushsafer->nrthreads--;
+
+	return (void *)NULL;
+}
+
+static int run(struct rules_actions_t *obj) {
+	pthread_t pth;
+	threads_create(&pth, NULL, thread, (void *)obj);
+	pthread_detach(pth);
+	return 0;
+}
+
+#if !defined(MODULE) && !defined(_WIN32)
+__attribute__((weak))
+#endif
+void actionPushsaferInit(void) {
+	event_action_register(&action_pushsafer, "pushsafer");
+
+	options_add(&action_pushsafer->options, 'a', "TITLE", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+	options_add(&action_pushsafer->options, 'b', "MESSAGE", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+	options_add(&action_pushsafer->options, 'c', "PRIVATEKEY", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+	options_add(&action_pushsafer->options, 'd', "DEVICE", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+	options_add(&action_pushsafer->options, 'e', "ICON", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+	options_add(&action_pushsafer->options, 'f', "SOUND", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+	options_add(&action_pushsafer->options, 'g', "VIBRATION", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+
+	action_pushsafer->run = &run;
+	action_pushsafer->checkArguments = &checkArguments;
+}
+
+#if defined(MODULE) && !defined(_WIN32)
+void compatibility(struct module_t *module) {
+	module->name = "pushsafer";
+	module->version = "1.0";
+	module->reqversion = "5.0";
+	module->reqcommit = "87";
+}
+
+void init(void) {
+	actionPushsaferInit();
+}
+#endif

--- a/libs/pilight/events/actions/pushsafer.h
+++ b/libs/pilight/events/actions/pushsafer.h
@@ -1,0 +1,30 @@
+/*
+	Copyright (C) 2013 - 2014 CurlyMo
+	
+	Copyright (C) 2016 Pushsafer.com Kevin Siml > Appzer.de
+
+	This file is part of pilight.
+
+	pilight is free software: you can redistribute it and/or modify it under the
+	terms of the GNU General Public License as published by the Free Software
+	Foundation, either version 3 of the License, or (at your option) any later
+	version.
+
+	pilight is distributed in the hope that it will be useful, but WITHOUT ANY
+	WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+	A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with pilight. If not, see	<http://www.gnu.org/licenses/>
+*/
+
+#ifndef _EVENT_ACTION_PUSHSAFER_H_
+#define _EVENT_ACTION_PUSHSAFER_H_
+
+#include "../action.h"
+
+struct event_actions_t *action_pushsafer;
+
+void actionPushsaferInit(void);
+
+#endif


### PR DESCRIPTION
API description: https://www.pushsafer.com/en/pushapi

Website description
=============

==== Pushsafer ====

**Version**\\
Available since pilight v7.0

**Description**\\
Send a message to your iOS, Android or Windows 10 (Phone, Dekstop) device with the Pushsafer API


**Options**
^name^required^multiple values^description^
|TITLE|x| |Self-explanatory|
|MESSAGE|x| |Self-explanatory|
|PRIVATEKEY|x| |Unique private or alias key from the pushsafer website|
|DEVICE|x| |Unique device or device group id from the pushsafer website|
|ICON|x| |a number 1-98 as described in the API|
|SOUND|x| |a number 0-28 or empty as described in the API|
|VIBRATION|x| |a number 1-3 or empty as described in the API|


**Examples**
<code>
IF 1 == 1 THEN pushsafer TITLE Doorbell rang MESSAGE Doorbell rang PRIVATEKEY abcd123abc DEVICE 101 ICON 5 SOUND 11 VIBRATION 2
</code>