### PR TITLE
modified daemon.c for receive-repeats rxrpt per protocol

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -606,10 +606,15 @@ void *receive_parse_code(void *param) {
 						protocol->repeats++;
 						if(protocol->parseCode != NULL) {
 							logprintf(LOG_DEBUG, "recevied pulse length of %d", recvqueue->plslen);
-							logprintf(LOG_DEBUG, "caught minimum # of repeats %d of %s", protocol->repeats, protocol->id);
 							logprintf(LOG_DEBUG, "called %s parseRaw()", protocol->id);
 							protocol->parseCode();
-							receiver_create_message(protocol);
+							if (protocol->repeats < protocol->rxrpt ) {
+								logprintf(LOG_DEBUG, "message discarded after %d repeats as minimum # of repeats %d of %s not reached", protocol->repeats, protocol->rxrpt, protocol->id);
+							}
+							else {
+								logprintf(LOG_DEBUG, "caught minimum # of repeats %d of %s", protocol->repeats, protocol->id);
+								receiver_create_message(protocol);
+							}
 						}
 					}
 				}

--- a/libs/pilight/protocols/433.92/arctech_screen_old.c
+++ b/libs/pilight/protocols/433.92/arctech_screen_old.c
@@ -203,7 +203,7 @@ void arctechScreenOldInit(void) {
 	arctech_screen_old->maxrawlen = RAW_LENGTH;
 	arctech_screen_old->maxgaplen = MAX_PULSE_LENGTH*PULSE_DIV;
 	arctech_screen_old->mingaplen = MIN_PULSE_LENGTH*PULSE_DIV;
-
+	arctech_screen_old->rxrpt = 2;
 	options_add(&arctech_screen_old->options, 't', "up", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
 	options_add(&arctech_screen_old->options, 'f', "down", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
 	options_add(&arctech_screen_old->options, 'u', "unit", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^([0-9]{1}|[1][0-5])$");

--- a/libs/pilight/protocols/433.92/arctech_switch_old.c
+++ b/libs/pilight/protocols/433.92/arctech_switch_old.c
@@ -220,7 +220,7 @@ void arctechSwitchOldInit(void) {
 	protocol_device_add(arctech_switch_old, "intertechno_old", "Old Intertechno Switches");
 	protocol_device_add(arctech_switch_old, "byebyestandby", "Bye Bye Standby Switches");
 	protocol_device_add(arctech_switch_old, "duwi", "Düwi Terminal Switches");
-//	arctech_switch_old->rxrpt=3;
+	arctech_switch_old->rxrpt=2;
 	arctech_switch_old->devtype = SWITCH;
 	arctech_switch_old->hwtype = RF433;
 	arctech_switch_old->minrawlen = RAW_LENGTH;

--- a/libs/pilight/protocols/433.92/arctech_switch_old.c
+++ b/libs/pilight/protocols/433.92/arctech_switch_old.c
@@ -65,7 +65,7 @@ static void parseCode(void) {
 		logprintf(LOG_ERR, "arctech_switch_old: parsecode - invalid parameter passed %d", arctech_switch_old->rawlen);
 		return;
 	}
-
+/*
 	for(x=0;x<arctech_switch_old->rawlen-3;x+=4) {
 		// valid telegrams must consist of 0110 and 1001 blocks
 		int low_high = 0;
@@ -92,7 +92,16 @@ static void parseCode(void) {
 				return; // invalid telegram
 		}
 	}
+*/
+       for(x=0;x<arctech_switch_old->rawlen-2;x+=4) {
+                if(arctech_switch_old->raw[x+3] > len) {
+                        binary[i++] = 0;
+                } else {
+                        binary[i++] = 1;
+                }
+        }
 
+   
 	int unit = binToDec(binary, 0, 3);
 	int state = binary[11];
 	int id = binToDec(binary, 4, 8);

--- a/libs/pilight/protocols/433.92/arctech_switch_old.c
+++ b/libs/pilight/protocols/433.92/arctech_switch_old.c
@@ -220,6 +220,7 @@ void arctechSwitchOldInit(void) {
 	protocol_device_add(arctech_switch_old, "intertechno_old", "Old Intertechno Switches");
 	protocol_device_add(arctech_switch_old, "byebyestandby", "Bye Bye Standby Switches");
 	protocol_device_add(arctech_switch_old, "duwi", "Düwi Terminal Switches");
+//	arctech_switch_old->rxrpt=3;
 	arctech_switch_old->devtype = SWITCH;
 	arctech_switch_old->hwtype = RF433;
 	arctech_switch_old->minrawlen = RAW_LENGTH;

--- a/libs/pilight/protocols/433.92/cleverwatts.c
+++ b/libs/pilight/protocols/433.92/cleverwatts.c
@@ -218,6 +218,7 @@ void cleverwattsInit(void) {
 	cleverwatts->maxrawlen = RAW_LENGTH;
 	cleverwatts->maxgaplen = MAX_PULSE_LENGTH*PULSE_DIV;
 	cleverwatts->mingaplen = MIN_PULSE_LENGTH*PULSE_DIV;
+	cleverwatts->rxrpt=3;
 
 	options_add(&cleverwatts->options, 't', "on", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
 	options_add(&cleverwatts->options, 'f', "off", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);

--- a/libs/pilight/protocols/433.92/heitech.c
+++ b/libs/pilight/protocols/433.92/heitech.c
@@ -209,6 +209,7 @@ void heitechInit(void) {
 	heitech->maxrawlen = RAW_LENGTH;
 	heitech->maxgaplen = MAX_PULSE_LENGTH*PULSE_DIV;
 	heitech->mingaplen = MIN_PULSE_LENGTH*PULSE_DIV;
+	heitech->rxrpt=3;
 
 	options_add(&heitech->options, 's', "systemcode", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^(3[012]?|[012][0-9]|[0-9]{1})$");
 	options_add(&heitech->options, 'u', "unitcode", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^(3[012]?|[012][0-9]|[0-9]{1})$");

--- a/libs/pilight/protocols/433.92/sc2262.c
+++ b/libs/pilight/protocols/433.92/sc2262.c
@@ -94,7 +94,7 @@ void sc2262Init(void) {
 	sc2262->maxrawlen = RAW_LENGTH;
 	sc2262->maxgaplen = MAX_PULSE_LENGTH*PULSE_DIV;
 	sc2262->mingaplen = MIN_PULSE_LENGTH*PULSE_DIV;
-
+	sc2262->rxrpt=2;
 	options_add(&sc2262->options, 's', "systemcode", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^(3[012]?|[012][0-9]|[0-9]{1})$");
 	options_add(&sc2262->options, 'u', "unitcode", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^(3[012]?|[012][0-9]|[0-9]{1})$");
 	options_add(&sc2262->options, 't', "opened", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);

--- a/libs/pilight/protocols/433.92/teknihall.c
+++ b/libs/pilight/protocols/433.92/teknihall.c
@@ -77,7 +77,7 @@ static void parseCode(void) {
 
 	id = binToDecRev(binary, 0, 7);
 	battery = binary[8];
-	temperature = binToDecRev(binary, 14, 23);
+	temperature = binToSignedRev(binary, 14, 23);
 	humidity = binToDecRev(binary, 24, 30);
 
 	struct settings_t *tmp = settings;

--- a/libs/pilight/protocols/433.92/teknihall.c
+++ b/libs/pilight/protocols/433.92/teknihall.c
@@ -77,7 +77,7 @@ static void parseCode(void) {
 
 	id = binToDecRev(binary, 0, 7);
 	battery = binary[8];
-	temperature = binToSignedRev(binary, 14, 23);
+	temperature = binToDecRev(binary, 14, 23);
 	humidity = binToDecRev(binary, 24, 30);
 
 	struct settings_t *tmp = settings;


### PR DESCRIPTION
this adds a check for protocol->rxrpt to daemon.c Purpose: avoid false alarms with desired protocols and enable us to set receive-repeats on a protocol level. In some configurations (e.g. smoke detectors) it is desirable to add a minimum of receive repeats before triggering an alarm. If you modify rxrpt in your protocol to a value n>1, the first n-1 receives will be discarded.