### PR TITLE
Dimmer patches

### DIFF
--- a/libs/pilight/protocols/generic/generic_dimmer.c
+++ b/libs/pilight/protocols/generic/generic_dimmer.c
@@ -30,6 +30,9 @@
 #include "../../core/gc.h"
 #include "generic_dimmer.h"
 
+#define MIN_DIMMER_VALUE 0
+#define MAX_DIMMER_VALUE 15
+
 static void createMessage(int id, int state, int dimlevel) {
 	generic_dimmer->message = json_mkobject();
 	json_append_member(generic_dimmer->message, "id", json_mknumber(id, 0));
@@ -46,8 +49,8 @@ static void createMessage(int id, int state, int dimlevel) {
 
 static int checkValues(JsonNode *code) {
 	int dimlevel = -1;
-	int max = 15;
-	int min = 0;
+	int max = MAX_DIMMER_VALUE;
+	int min = MIN_DIMMER_VALUE;
 	double itmp = -1;
 
 	if(json_find_number(code, "dimlevel-maximum", &itmp) == 0)
@@ -75,8 +78,8 @@ static int createCode(JsonNode *code) {
 	int id = -1;
 	int state = -1;
 	int dimlevel = -1;
-	int max = 10;
-	int min = 0;
+	int max = MAX_DIMMER_VALUE;
+	int min = MIN_DIMMER_VALUE;
 	double itmp = -1;
 
 	if(json_find_number(code, "dimlevel-maximum", &itmp) == 0)
@@ -147,7 +150,7 @@ void genericDimmerInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "generic_dimmer";
-	module->version = "1.4";
+	module->version = "1.5";
 	module->reqversion = "6.0";
 	module->reqcommit = "84";
 }

--- a/libs/webgui/pilight.js
+++ b/libs/webgui/pilight.js
@@ -461,7 +461,7 @@ function createDimmerElement(sTabId, sDevId, aValues) {
 			oTab = $('#all');
 		}
 		if('name' in aValues && 'dimlevel-minimum' in aValues && 'dimlevel-maximum' in aValues) {
-			oTab.append($('<li id="'+sDevId+'" class="dimmer" data-icon="false"><div class="name">'+aValues['name']+'</div><select id="'+sDevId+'_switch" data-role="slider"><option value="off">'+language.off+'</option><option value="on">'+language.on+'</option></select><div id="'+sDevId+'_dimmer" min="'+aValues['dimlevel-minimum']+'" max="'+aValues['dimlevel-maximum']+'" data-highlight="true" ><input type="value" id="'+sDevId+'_value" class="slider-value dimmer-slider ui-slider-input ui-input-text ui-body-c ui-corner-all ui-shadow-inset" /></div></li>'));
+			oTab.append($('<li id="'+sDevId+'" class="dimmer" data-icon="false"><div class="name">'+aValues['name']+'</div><select id="'+sDevId+'_switch" data-role="slider"><option value="off">'+language.off+'</option><option value="on">'+language.on+'</option></select><div id="'+sDevId+'_dimmer" min="'+aValues['dimlevel-minimum']+'" max="'+aValues['dimlevel-maximum']+'" data-highlight="true" ><input type="value" id="'+sDevId+'_value" class="slider-value dimmer-slider ui-slider-input ui-input-text ui-body-c ui-corner-all ui-shadow-inset" disabled="true"/></div></li>'));
 		}
 		$('#'+sDevId+'_switch').slider();
 		$('#'+sDevId+'_switch').bind("change", function(event, ui) {
@@ -921,6 +921,7 @@ function parseValues(data) {
 					}
 					if(vindex == 'dimlevel') {
 						aDimLevel[dvalues] = vvalues;
+						$('#'+dvalues+'_value').val(vvalues);
 						$('#'+dvalues+'_dimmer').val(vvalues);
 						$('#'+dvalues+'_dimmer').slider('refresh');
 					}


### PR DESCRIPTION
Fix 2 dimmer bugs

These are two separate commits since they are quite different, yet I feel that they are too similar to warrant opening separate PRs. Hope that's fine.

Discussion: https://forum.pilight.org/Thread-Dimlevel-text-in-WebGUI-0-and-not-updated

Commit messages: 

----
Webgui: Fix dimmer display bugs

This would cause the text field next to the slider to be
initialized to 0 at page load, even though the slider was showing the
correct dimlevel.

This commit fixes this by also assigning the dimlevel to the text field on
page load. Patch by @Niek.

Further, the slider-input field was editable, but without use (editing the
value has no effect). Therefore, display the field as disabled.

----

generic_dimmer: Fix inconsistency

The default max values were defined to different values in the checkValues and
createCode functions, causing the webgui to not transmit slider changes to
values above 10.
This commit fixes this by setting the default to 15 in both functions.