### PR TITLE
daemon: Add version packet sent after {"request values"}

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -1394,6 +1394,14 @@ static void socket_parse_data(int i, char *buffer) {
 					socket_write(sd, output);
 					json_free(output);
 					json_delete(jsend);
+					/* send version packet */ 
+					struct JsonNode *jsend_version = json_mkobject();
+					json_append_member(jsend_version, "version", json_mkstring(PILIGHT_VERSION));
+					char *output_version = json_stringify(jsend_version, NULL);
+					socket_write(sd, output_version);
+					json_free(output_version);
+					json_delete(jsend_version);
+
 				/*
 				 * Parse received codes from nodes
 				 */


### PR DESCRIPTION
Send a json object immediately after replying to a `{"request values"}` socket
API message was received. Up to GUIs and other software using the API to parse
this.

The version packet looks like: `{"version":"7.0"}`

This is documented in the documentation already, but it wasn't actually present in the code. But it's very useful for programs using the API, since it is better than reading values from the registry that could easily be modified. 