### PR TITLE
Teknihall: Use correct bits in signed temperature

### DIFF
--- a/libs/pilight/protocols/433.92/teknihall.c
+++ b/libs/pilight/protocols/433.92/teknihall.c
@@ -77,7 +77,7 @@ static void parseCode(void) {
 
 	id = binToDecRev(binary, 0, 7);
 	battery = binary[8];
-	temperature = binToSignedRev(binary, 14, 23);
+	temperature = binToSignedRev(binary, 13, 23);
 	humidity = binToDecRev(binary, 24, 30);
 
 	struct settings_t *tmp = settings;


### PR DESCRIPTION
Fixes mistake in 2f97e6a52b2c8fcdecaeff8e8748728446121e40

Sorry about that :/