### PR TITLE
Add schema export action for protocols

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -1265,6 +1265,23 @@ static void socket_parse_data(int i, char *buffer) {
 					} else {
 						socket_write(sd, "{\"status\":\"failed\"}");
 					}
+				} else if(strcmp(action, "list protocols") == 0) {
+					struct protocols_t *pnode = protocols;
+					struct JsonNode *schema = json_mkobject();
+					struct JsonNode *proto_schema = json_mkarray();
+
+					json_append_member(schema, "protocols", proto_schema);
+
+					/* iterate all protocols */
+					while(pnode) {
+						json_append_element(proto_schema, protocol_schema(pnode->listener));
+						pnode = pnode->next;
+					}
+
+					char *schema_message = json_stringify(schema, NULL);
+					socket_write(sd, schema_message);
+					json_free(schema_message);
+					json_delete(schema);
 				} else if(strcmp(action, "control") == 0) {
 					struct JsonNode *code = NULL;
 					struct devices_t *dev = NULL;

--- a/libs/pilight/core/json.c
+++ b/libs/pilight/core/json.c
@@ -1436,3 +1436,26 @@ int json_find_string(JsonNode *object, const char *name, char **out) {
 void json_free(void *a) {
 	free(a);
 }
+
+JsonNode *json_vartype(int vartype) {
+	JsonNode *vartype_array = json_mkarray();
+	if((vartype & JSON_NULL) != 0) {
+		json_append_element(vartype_array, json_mkstring("null"));
+	}
+	if((vartype & JSON_BOOL) != 0) {
+		json_append_element(vartype_array, json_mkstring("boolean"));
+	}
+	if((vartype & JSON_STRING) != 0) {
+		json_append_element(vartype_array, json_mkstring("string"));
+	}
+	if((vartype & JSON_NUMBER) != 0) {
+		json_append_element(vartype_array, json_mkstring("number"));
+	}
+	if((vartype & JSON_ARRAY) != 0) {
+		json_append_element(vartype_array, json_mkstring("array"));
+	}
+	if((vartype & JSON_OBJECT) != 0) {
+		json_append_element(vartype_array, json_mkstring("object"));
+	}
+	return vartype_array;
+}

--- a/libs/pilight/core/json.h
+++ b/libs/pilight/core/json.h
@@ -121,4 +121,6 @@ bool json_check(const JsonNode *node, char errmsg[256]);
 int json_find_number(JsonNode *object, const char *name, double *out);
 int json_find_string(JsonNode *object, const char *name, char **out);
 
+JsonNode *json_vartype(int vartype);
+
 #endif

--- a/libs/pilight/protocols/protocol.c
+++ b/libs/pilight/protocols/protocol.c
@@ -347,6 +347,39 @@ void protocol_device_add(protocol_t *proto, const char *id, const char *desc) {
 	proto->devices = dnode;
 }
 
+JsonNode *protocol_schema(protocol_t *proto) {
+	JsonNode *root = json_mkobject();
+
+	json_append_member(root, "name", json_mkstring(proto->id));
+
+	JsonNode *devices = json_mkarray();
+	json_append_member(root, "devices", devices);
+
+	struct protocol_devices_t *dev_temp = proto->devices;
+	while(dev_temp) {
+		json_append_element(devices, json_mkstring(dev_temp->id));
+		dev_temp = dev_temp->next;
+	}
+
+
+	JsonNode *options = json_mkarray();
+	json_append_member(root, "options", options);
+
+	struct options_t *opt_temp = proto->options;
+	while(opt_temp) {
+		if(opt_temp->id != 0) {
+			JsonNode *option = json_mkobject();
+			json_append_element(options, option);
+
+			json_append_member(option, "name", json_mkstring(opt_temp->name));
+			json_append_member(option, "vartype", json_vartype(opt_temp->vartype));
+		}
+		opt_temp = opt_temp->next;
+	}
+
+	return root;
+}
+
 int protocol_device_exists(protocol_t *proto, const char *id) {
 	logprintf(LOG_STACK, "%s(...)", __FUNCTION__);
 

--- a/libs/pilight/protocols/protocol.h
+++ b/libs/pilight/protocols/protocol.h
@@ -128,6 +128,7 @@ void protocol_set_id(protocol_t *proto, const char *id);
 void protocol_plslen_add(protocol_t *proto, int plslen);
 void protocol_register(protocol_t **proto);
 void protocol_device_add(protocol_t *proto, const char *id, const char *desc);
+JsonNode *protocol_schema(protocol_t *proto);
 int protocol_device_exists(protocol_t *proto, const char *id);
 int protocol_gc(void);
 


### PR DESCRIPTION
This adds a new action called "protocol_schema" to the daemon, to
export the send-schema for all supported protocols to a client. This
can be used to build client-side data validation for better error
propagation and/or mor stable api implementations.

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>