### PR TITLE
Make json type defines useable as bitmask

### DIFF
--- a/libs/pilight/core/json.h
+++ b/libs/pilight/core/json.h
@@ -28,12 +28,12 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#define JSON_NULL		0x1
-#define JSON_BOOL		0x2
-#define JSON_STRING	0x4
-#define JSON_NUMBER 0x8
-#define JSON_ARRAY	0x16
-#define JSON_OBJECT	0x23
+#define JSON_NULL	0x01
+#define JSON_BOOL	0x01 << 1
+#define JSON_STRING	0x01 << 2
+#define JSON_NUMBER	0x01 << 3
+#define JSON_ARRAY	0x01 << 4
+#define JSON_OBJECT	0x01 << 5
 
 #define JsonTag			int
 


### PR DESCRIPTION
The former json types could not easily be used as bitmask, because the
values had some bits in common. For example JSON_STRING (0x04) and
JSON_ARRAY (0x16) had both the third bit set to true. So a calue
defined as JSON_ARRAY had internally the same value as
(JSON_STRING | JSON_ARRAY).

This is a problem, since for example teh generic_label protocol uses
bitwise or to declare a parameter as "multiple types" (in this case its
JSON_STRING | JSON_NUMBER.

This uses bitshifts to define differentiable values.

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>