### PR TITLE
Bugfix - Update init.d script: Remove pilight stop for runlevel 2

### DIFF
--- a/res/init/pilight.initd
+++ b/res/init/pilight.initd
@@ -4,7 +4,7 @@
 # Required-Start:    $network $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     3 4 5
-# Default-Stop:      0 1 2 6
+# Default-Stop:      0 1 6
 # Short-Description: Starts pilight-daemon
 # Description:       Starts pilight-daemon
 #


### PR DESCRIPTION
https://forum.pilight.org/Thread-Raspbian-jessie-pilight-7-no-pilight-ssdp-connections-found?pid=20422#pid20422
If you get an insserv warning, you may have to remove manually the following link from /etc/rc2.d:
lrwxrwxrwx  1 root root   17 Feb 27  2016 S02pilight -> ../init.d/pilight
