### PR TITLE
Respect node UUID configuration also for RF433 and RF868 devices.

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -1083,7 +1083,9 @@ static int control_device(struct devices_t *dev, char *state, struct JsonNode *v
 	/* Construct the right json object */
 	json_append_member(code, "protocol", jprotocols);
 	if(dev->dev_uuid != NULL && (dev->protocols->listener->hwtype == SENSOR
-	   || dev->protocols->listener->hwtype == HWRELAY)) {
+	   || dev->protocols->listener->hwtype == HWRELAY
+	   || dev->protocols->listener->hwtype == RF433
+	   || dev->protocols->listener->hwtype == RF868)) {
 		json_append_member(code, "uuid", json_mkstring(dev->dev_uuid));
 	}
 	json_append_member(json, "code", code);

--- a/libs/pilight/config/devices.c
+++ b/libs/pilight/config/devices.c
@@ -434,7 +434,8 @@ int devices_update(char *protoname, JsonNode *json, enum origin_t origin, JsonNo
 	if(update == 1) {
 		json_append_member(rroot, "origin", json_mkstring("update"));
 		json_append_member(rroot, "type",  json_mknumber((int)protocol->devtype, 0));
-		if(strlen(pilight_uuid) > 0 && (protocol->hwtype == SENSOR || protocol->hwtype == HWRELAY)) {
+		if(strlen(pilight_uuid) > 0 && 
+		  (protocol->hwtype == SENSOR || protocol->hwtype == HWRELAY || protocol->hwtype == RF433 || protocol->hwtype == RF868)) {
 			json_append_member(rroot, "uuid",  json_mkstring(pilight_uuid));
 		}
 		json_append_member(rroot, "devices", rdev);


### PR DESCRIPTION
Small change to allow pilight's adhoc network feature to respect optionally configured node UUIDs also for RF433 and RF868 devices. This can be used to prevent interference if multiple pilight nodes that are relatively close to one another try to send the same command at the same time.
The same change / enhancement was also announced for the pilight rewrite.