### PR TITLE
Create manpages for all pilight programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,8 @@ if(${MODULESPACK} MATCHES "OFF" OR WIN32)
 		install(FILES ${CMAKE_BINARY_DIR}/lib${PROJECT_NAME}.so DESTINATION lib/${PROJECT_NAME}/ RENAME lib${PROJECT_NAME}.so.${VERSION} COMPONENT ${PROJECT_NAME})
 		install(FILES ${CMAKE_BINARY_DIR}/lib${PROJECT_NAME}.a DESTINATION lib/${PROJECT_NAME}/ RENAME lib${PROJECT_NAME}.a COMPONENT ${PROJECT_NAME})
 		install(CODE "execute_process(COMMAND ln -s \"/usr/local/lib/${PROJECT_NAME}/lib${PROJECT_NAME}.so.${VERSION}\" \"/usr/local/lib/lib${PROJECT_NAME}.so\")")	
+		install(DIRECTORY doc/ DESTINATION /usr/share/man/man1 COMPONENT ${PROJECT_NAME})
+		install(CODE "execute_process(COMMAND mandb -q)")
 
 		if(EXISTS "/usr/local/lib/${PROJECT_NAME}/protocols")
 			install(CODE "execute_process(COMMAND find /usr/local/lib/${PROJECT_NAME}/protocols/ -type f -exec rm {} \\;)")

--- a/doc/pilight-control.1
+++ b/doc/pilight-control.1
@@ -1,0 +1,67 @@
+.TH pilight-control 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-control \- Control pilight devices
+.SH SYNOPSIS
+.B pilight-control \fI--device DEVICE\fR \fI--state STATE\fR
+.br
+.B pilight-control [\fIOPTION\fR]... \fI--device DEVICE\fR \fI--values VALUES\fR
+.br
+.B pilight-control [\fI--server SERVER\fR] [\fI --port PORT\fR] [\fIOPTION\fR]... \fI--device DEVICE\fR
+.SH DESCRIPTION
+.B pilight-control
+is a tool to control a device configured in a pilight daemon configuration. It supports switching the state and/or modifying other values (such as dimlevel, temperature, or humidity) of the device.
+.PP
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-S\fR, \fB\-\-server\fR=\fIx.x.x.x\fR
+Connect to a pilight daemon at this address. Requires \fB-P\fR
+.TP
+\fB\-P\fR, \fB\-\-port\fR=\fIxxxx\fR
+Connect to a pilight daemon at this port. Requires \fB-S\fR
+.TP
+\fB\-C\fR, \fB\-\-config\fR=\fIPATH_TO_CONFIG\fR
+.\" FIXME: Is this even needed in pilight-control? What is it for?
+Path to configuration file
+.TP
+\fB\-d\fR, \fB\-\-device\fR=\fIDEVICE_NAME\fR
+Name of the configured device to be controlled
+.TP
+\fB\-s\fR, \fB\-\-state\fR=\fISTATE\fR
+State to switch DEVICE to
+.TP
+\fB\-v\fR, \fB\-\-values\fR=\fIVALUES\fR
+Supply other values for DEVICE, such as \fIdimlevel=10\fR
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-daemon(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-sha256(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-daemon.1
+++ b/doc/pilight-daemon.1
@@ -1,0 +1,87 @@
+.TH pilight-daemon 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-daemon \- The pilight daemon
+.SH SYNOPSIS
+.B pilight-daemon
+.br
+.B pilight-daemon [\fIOPTION\fR]...
+.br
+.B pilight-daemon [\fI--server SERVER\fR] [\fI --port PORT\fR] [\fIOPTION\fR]...
+.SH DESCRIPTION
+.B pilight-daemon
+is the main software of the pilight project. It is responsible for handling and
+interpreting received signals, as well as generating signals to communicate
+with and control various devices.
+.PP
+A configuration file is required. By default, /etc/pilight/config.json is used.
+Configuration files are written in the JSON format.
+.PP
+Consult the pilight wiki <https://wiki.pilight.org/> and the manual
+<https://manual.pilight.org/> for details on how to configure and use pilight.
+.PP
+By default, the pilight daemon hosts a webgui which allows controlling devices
+through a clickable interface in a webbrowser.
+The pilight daemon runs a socket server and provides a REST API to interface
+with the pilight daemon.
+.PP
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-C\fR, \fB\-\-config\fR=\fIPATH\fR
+Specify to use configuration file at PATH rather than standard configuration
+.TP
+\fB\-S\fR, \fB\-\-server\fR=\fIx.x.x.x\fR
+Connect to a pilight daemon at this address. Requires \fB-P\fR
+.TP
+\fB\-P\fR, \fB\-\-port\fR=\fIxxxx\fR
+Connect to a pilight daemon at this port. Requires \fB-S\fR
+.TP
+\fB\-F\fR, \fB\-\-foreground\fR
+Do not daemonize
+.TP
+\fB\-D\fR, \fB\-\-debug\fR
+Do not daemonize and print more debug information
+.PP
+.B Debugging options:
+.PP
+\fB\-\-stacktracer\fR
+Show internal function calls
+.TP
+\fB\-\-threadprofiler\fR
+Show per thread CPU usage
+.TP
+\fB\-\-debuglevel\fR
+Show additional development information
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-sha256(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-debug.1
+++ b/doc/pilight-debug.1
@@ -1,0 +1,53 @@
+.TH pilight-debug 1 "10 July 2016" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-debug \- Decode incoming raw streams into logical pulsetrains
+.SH SYNOPSIS
+.B pilight-debug
+.br
+.B pilight-debug [\fIOPTION\fR]...
+.SH DESCRIPTION
+.B pilight-debug
+is a tool to decode incoming raw streams into logical pulsetrains. It also 
+prints certain calculated parameters of the caught pulsetrain.
+.PP
+Prints data to STDOUT until interrupted with ^C.
+.PP
+This tool requires root privileges.
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-C\fR, \fB\-\-config\fR=\fIPATH_TO_CONFIG\fR
+Path to configuration file
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-daemon(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-sha256(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-flash.1
+++ b/doc/pilight-flash.1
@@ -7,20 +7,19 @@ pilight-flash \- Flash hardware with pilight firmware
 .B pilight-control [\fIOPTION\fR]... \fI--file FIRMWARE_FILE\fR
 .SH DESCRIPTION
 .B pilight-control
-is a tool to flash pilight firmware to hardware such as ATMel chips (such as
-the ATTiny and ATMega).
+is a tool to flash pilight firmware to ATMel chips (such as the ATTiny and
+ATMega).
 .PP
 The pilight ATMel firmware pre-filters streams and prevents noise from
-reaching the pilight daemon. This lowers CPU usage by the pilight daemon
-greatly, because it will not attempt to continuously interpret noise as valid
-protocols. Currently supported chips are the ATTiny25, ATTiny45, ATTiny85, and
-ATMega328P.
+reaching the pilight daemon. This lowers the CPU usage of the pilight daemon
+greatly, because the pilight daemon will not continuously attempt to interpret
+noise as valid protocols. 
+Currently supported chips are the ATTiny25, ATTiny45, ATTiny85, and ATMega328P.
 .PP
-The ATMel firmware is necessary for using pilight with senders and receivers
-on non-GPIO capable hardware (most desktops, servers, etc.), but it can be also
-be used with GPIO capable hardware to act as a pre-filter for received signals.
-The flashed chip is connected via USB, and the sender and receiver are wired to
-the GPIO pins on the chip.
+Besides acting as a pre-filter, the firmware also allows using pilight with 
+senders and receivers on non GPIO-capable hardware (such as most desktops, 
+servers, etc.) The flashed ATMega chip is connected via USB, and the sender and
+receiver are wired to the GPIO pins on the chip.
 Consult the pilight wiki <https://wiki.pilight.org/> and the manual
 <https://manual.pilight.org/> for wiring schematics.
 .PP

--- a/doc/pilight-flash.1
+++ b/doc/pilight-flash.1
@@ -1,0 +1,68 @@
+.TH pilight-flash 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-flash \- Flash hardware with pilight firmware
+.SH SYNOPSIS
+.B pilight-flash \fI--file FIRMWARE_FILE\fR
+.br
+.B pilight-control [\fIOPTION\fR]... \fI--file FIRMWARE_FILE\fR
+.SH DESCRIPTION
+.B pilight-control
+is a tool to flash pilight firmware to hardware such as ATMel chips (such as
+the ATTiny and ATMega).
+.PP
+The pilight ATMel firmware pre-filters streams and prevents noise from
+reaching the pilight daemon. This lowers CPU usage by the pilight daemon
+greatly, because it will not attempt to continuously interpret noise as valid
+protocols. Currently supported chips are the ATTiny25, ATTiny45, ATTiny85, and
+ATMega328P.
+.PP
+The ATMel firmware is necessary for using pilight with senders and receivers
+on non-GPIO capable hardware (most desktops, servers, etc.), but it can be also
+be used with GPIO capable hardware to act as a pre-filter for received signals.
+The flashed chip is connected via USB, and the sender and receiver are wired to
+the GPIO pins on the chip.
+Consult the pilight wiki <https://wiki.pilight.org/> and the manual
+<https://manual.pilight.org/> for wiring schematics.
+.PP
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-C\fR, \fB\-\-config\fR=\fIPATH_TO_CONFIG\fR
+Configuration file to be used. The config contains comport or GPIO pin numbers
+needed for communicating with chip.
+.TP
+\fB\-f\fR, \fB\-\-file\fR=\fIPATH_TO_FIRMWARE\fR
+Firmware file to flashed
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-daemon(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-sha256(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-raw.1
+++ b/doc/pilight-raw.1
@@ -1,0 +1,56 @@
+.TH pilight-raw 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-raw \- Print received raw streams
+.SH SYNOPSIS
+.B pilight-raw
+.br
+.B pilight-raw [\fIOPTION\fR]...
+.SH DESCRIPTION
+.B pilight-raw
+is a tool to print raw streams as they are picked up by the receiver hardware.
+.PP
+Prints data to STDOUT until interrupted with ^C.
+.PP
+This tool requires root privileges.
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-L\fR, \fB\-\-linefeed\fR
+Structure raw printout with newlines between (probably) separate 
+pulsetrains.
+.TP
+\fB\-C\fR, \fB\-\-config\fR=\fIPATH_TO_CONFIG\fR
+Path to configuration file
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-daemon(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-sha256(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-receive.1
+++ b/doc/pilight-receive.1
@@ -1,0 +1,65 @@
+.TH pilight-receive 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-receive \- Show datagrams received and transmitted by pilight
+.SH SYNOPSIS
+.B pilight-receive 
+.br
+.B pilight-receive [\fIOPTION\fR]... 
+.br
+.B pilight-receive [\fI--server SERVER\fR] [\fI --port PORT\fR] [\fIOPTION\fR]... \fI--device DEVICE\fR
+.SH DESCRIPTION
+.B pilight-receive
+is a tool to show all data that is sent and received by a pilight daemon 
+instance or a pilight adhoc network. All data is shown as-is in JSON format.
+.PP
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-S\fR, \fB\-\-server\fR=\fIx.x.x.x\fR
+Connect to a pilight daemon at this address. Requires \fB-P\fR
+.TP
+\fB\-P\fR, \fB\-\-port\fR=\fIxxxx\fR
+Connect to a pilight daemon at this port. Requires \fB-S\fR
+.TP
+\fB\-s\fR, \fB\-\-stats\fR
+show CPU and RAM statistics in output
+.TP
+\fB\-F\fR, \fB\-\-filter\fR=\fIPROTOCOL(S)\fR
+Specify protocols that should not be printed in the output stream. This is
+useful when trying to find IDs of devices such as weather stations or remote
+controls, but certain protocols are spamming the output. For example, datetime
+protocol data is transmitted every second, and is likely to displace useful 
+information in the output stream. It can then be hidden with \fI--filter=datetime\fR
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-daemon(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-sha256(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-send.1
+++ b/doc/pilight-send.1
@@ -1,0 +1,140 @@
+.TH pilight-send 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-send \- Send data to a pilight daemon
+.SH SYNOPSIS
+.B pilight-send \fI--protocol PROTOCOL\fR [\fIOPTION\fR]...
+.br
+.B pilight-send [\fI--server SERVER\fR] [\fI --port PORT\fR] \fI--protocol PROTOCOL\fR [\fIOPTION\fR]...
+.SH DESCRIPTION
+.B pilight-send
+is a tool to send data to a pilight daemon instance. It is a more versatile
+tool than \fBpilight-control(1)\fR, because it does not require the device to
+be previously configured. 
+.PP
+It can be used to send signals for any pilight protocol that supports sending.
+.PP
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-p\fR, \fB\-\-protocol\fR=\fIPROTOCOL\fR
+Protocol to be sent
+.TP
+\fB\-S\fR, \fB\-\-server\fR=\fIx.x.x.x\fR
+Connect to a pilight daemon at this address. Requires \fB-P\fR
+.TP
+\fB\-P\fR, \fB\-\-port\fR=\fIxxxx\fR
+Connect to a pilight daemon at this port. Requires \fB-S\fR
+.TP
+\fB\-C\fR, \fB\-\-config\fR=\fIPATH_TO_CONFIG\fR
+Path to configuration file
+.TP
+\fB\-U\fR, \fB\-\-uuid\fR=\fIUUID\fR
+UUID to identify as when connecting to the pilight daemon
+.TP
+Further options are required, depending on the chosen protocol. Use
+\fIpilight-send_-p_PROTOCOL_--help\fR to find which options are required for
+the protocol. Some long options differ between protocols. Protocol options
+include:
+.TP
+\fB\-a\fR, \fB\-\-all\fR, \fB\-\-id=all\fR
+Send command to all devices with the same ID
+.TP
+\fB\-a\fR, \fB\-\-api\fR=\fIAPI_KEY\fR
+Update a Weather Underground entry with the API code
+.TP
+\fB\-b\fR, \fB\-\-battery\fR=\fIBATTERY\fR
+Send battery state (0 = low, 1 = normal) for weather stations
+.TP
+\fB\-c\fR, \fB\-\-code\fR=\fIRAW_CODE\fR
+Raw code to be transmitted, as emitted by pilight-debug
+.TP
+\fB\-c\fR, \fB\-\-color\fR=\fICOLOR\fR
+Set a label device to this text color
+.TP
+\fB\-c\fR, \fB\-\-country\fR=\fICOUNTRY\fR
+Update a Weather Underground entry with this country
+.TP
+\fB\-d\fR, \fB\-\-dimlevel\fR=\fIDIMLEVEL\fR
+Set a dimmer to a specific dimlevel
+.TP
+\fB\-f\fR, \fB\-\-off\fR, \fB\-\-down\fR, \fB\-\-stopped\fR
+Send an 'off' (for switches) or 'down' (for screens) or 'stopped' (for 
+programs) signal
+.TP
+\fB\-g\fR, \fB\-\-gpio\fR=\fIGPIO\fR
+GPIO pin number a device (for example a relay) is connected to
+.TP
+\fB\-h\fR, \fB\-\-humidity\fR=\fIHUMIDITY\fR
+Send humidity value for a weather station
+.TP
+\fB\-i\fR, \fB\-\-id\fR=\fIID\fR
+Send a code with this id
+.TP
+\fB\-l\fR, \fB\-\-label\fR=\fILABEL\fR
+Set text of a label device to this text
+.TP
+\fB\-l\fR, \fB\-\-learn\fR
+Send multiple streams when a device is in learning mode to emulate the learning
+mode of a remote control.
+.TP
+\fB\-l\fR, \fB\-\-location\fR=\fILOCATION\fR
+Update a Weather Underground entry with this location
+.TP
+\fB\-n\fR, \fB\-\-name\fR=\fINAME\fR
+Name of the program to be controlled
+.TP
+\fB\-n\fR, \fB\-\-num\fR
+Use random (super)code sequence number 0..3 (7)
+.TP
+\fB\-s\fR, \fB\-\-systemcode\fR=\fISYSTEMCODE\fR
+Send a code with this systemcode
+.TP
+\fB\-s\fR, \fB\-\-super\fR
+Send to all devices, regardless of id
+.TP
+\fB\-t\fR, \fB\-\-on\fR, \fB\-\-up\fR, \fB\-\-running\fR
+Send an 'on' (for switches) or 'up' (for screens) or 'running' (for programs)
+signal
+.TP
+\fB\-t\fR, \fB\-\-temperature\fR=\fITEMPERATURE\fR
+Send temperature value for a weather station
+.TP
+\fB\-u\fR, \fB\-\-unit\fR=\fIUNITCODE\fR, \fB\-\-unitcode\fR=\fIUNITCODE\fR, \fB\-\-programcode\fR=\fIPROGRAMCODE\fR
+Send a code this unitcode. Note that some protocols use long option \fI--unit\fR
+while others use long option \fI--unitcode\fR or long option \fI--programcode\fR.
+.TP
+\fB\-u\fR, \fB\-\-update
+Update a defined Weather Underground entry
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-daemon(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-sha256(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-sha256.1
+++ b/doc/pilight-sha256.1
@@ -1,0 +1,54 @@
+.TH pilight-sha256 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-sha256 \- Generate a pilight SHA-256 hash for a password
+.SH SYNOPSIS
+.B pilight-sha256 \fI--password PASSWORD\fR
+.SH DESCRIPTION
+.B pilight-sha256
+is a tool to generate a SHA-256 hash for a webgui password to avoid storing
+cleartext passwords in configuration files. 
+.PP
+The hash can be added to config.json under "settings"\->"webserver-password".
+Consult the pilight wiki <http://wiki.pilight.org/> for configuration details.
+.PP
+Prints the hashed PASSWORD to STDOUT. 
+.PP
+.SH OPTIONS
+Mandatory arguments to long options are mandatory for short options too.
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.TP
+\fB\-p\fR, \fB\-\-password\fR=\fIPASSWORD\fR
+Password to hash
+.PP
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-daemon(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-uuid(1)

--- a/doc/pilight-uuid.1
+++ b/doc/pilight-uuid.1
@@ -1,0 +1,48 @@
+.TH pilight-uuid 1 "10 July 2017" "7.0-dev" "pilight 7.0-dev"
+.SH NAME
+pilight-uuid \- Show pilight adhoc node UUID
+.SH SYNOPSIS
+.B pilight-uuid
+.SH DESCRIPTION
+.B pilight-uuid
+is a tool to show the UUID for a pilight adhoc network node in order to
+identify as a unique node. This prevents multiple nodes from interfering with 
+each other when sending and receiving.
+.PP
+Prints the UUID to STDOUT.
+.PP
+.SH OPTIONS
+.TP
+\fB\-H\fR, \fB\-\-help\fR
+Print allowed options and exit
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version information and exit
+.PP
+.SH BUGS
+Please report all bugs on GitHub <https://github.com/pilight/pilight/>.
+.SH AUTHOR
+.PP
+Curlymo <info@pilight.org>
+and contributors.
+.PP
+This man page was originally written by
+pilino1234 <pilino1234@zoho.eu>.
+.SH WWW
+https://www.pilight.org/
+.SH SEE ALSO
+.B pilight-control(1)
+.br
+.B pilight-daemon(1)
+.br
+.B pilight-debug(1)
+.br
+.B pilight-flash(1)
+.br
+.B pilight-raw(1)
+.br
+.B pilight-receive(1)
+.br
+.B pilight-send(1)
+.br
+.B pilight-sha256(1)


### PR DESCRIPTION
Quite self-explanatory

Now automatically install manpages to `/usr/share/man/man1`. Tested and confirmed working, but comments on the CMake stuff are welcome. 

Use `sudo make install` to test. Output should look like this:
```-- Installing: /usr/share/man/man1/pilight-sha256.1
-- Installing: /usr/share/man/man1/pilight-control.1
-- Installing: /usr/share/man/man1/pilight-raw.1
-- Installing: /usr/share/man/man1/pilight-debug.1
-- Installing: /usr/share/man/man1/pilight-flash.1
-- Installing: /usr/share/man/man1/pilight-send.1
-- Installing: /usr/share/man/man1/pilight-uuid.1
-- Installing: /usr/share/man/man1/pilight-receive.1
-- Installing: /usr/share/man/man1/pilight-daemon.1
```
Then use `man` to view the manpages.

Will squash soon.

___
~~(These are currently not installed though, I'm still tinkering with CMakeLists.txt to make it do what I want it to. If anyone knows how to make CMake install manpages, I would appreciate any help!)~~