### PR TITLE
added ds_4 protocol

### DIFF
--- a/CMakeConfig.txt
+++ b/CMakeConfig.txt
@@ -22,6 +22,7 @@ set(PROTOCOL_DATETIME ON CACHE BOOL "support for the (NTP) date and time protoco
 set(PROTOCOL_DAYCOM ON CACHE BOOL "support Daycom switch (Pollin)")
 set(PROTOCOL_DS18B20 ON CACHE BOOL "support for the 1-Wire ds18b20 temperature sensor")
 set(PROTOCOL_DS18S20 ON CACHE BOOL "support for the 1-Wire ds18s20 temperature sensor")
+set(PROTOCOL_DS_4 ON CACHE BOOL "support for the DS-4 contact sensor (deviation from EV1527")
 set(PROTOCOL_DHT11 ON CACHE BOOL "support for the DHT11 temperature-humidity sensor")
 set(PROTOCOL_DHT22 ON CACHE BOOL "support for the DHT22/AM2302 temperature-humidity sensor")
 set(PROTOCOL_DIO_SWITCH ON CACHE BOOL "support for the D-IO switch protocol")

--- a/libs/pilight/protocols/433.92/ds_4.c
+++ b/libs/pilight/protocols/433.92/ds_4.c
@@ -1,0 +1,120 @@
+/*
+	Copyright (C) 2017 Torwag
+	
+	This file is part of pilight.
+
+	pilight is free software: you can redistribute it and/or modify it under the
+	terms of the GNU General Public License as published by the Free Software
+	Foundation, either version 3 of the License, or (at your option) any later
+	version.
+
+	pilight is distributed in the hope that it will be useful, but WITHOUT ANY
+	WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+	A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with pilight. If not, see	<http://www.gnu.org/licenses/>
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "../../core/pilight.h"
+#include "../../core/common.h"
+#include "../../core/dso.h"
+#include "../../core/log.h"
+#include "../protocol.h"
+#include "../../core/binary.h"
+#include "../../core/gc.h"
+#include "ds_4.h"
+
+#define PULSE_MULTIPLIER	3
+#define MIN_PULSE_LENGTH	350
+#define MAX_PULSE_LENGTH	550
+#define AVG_PULSE_LENGTH	470
+#define RAW_LENGTH		50
+
+static int validate(void) {
+	if(ds_4->rawlen == RAW_LENGTH) {
+		if(ds_4->raw[ds_4->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&
+		   ds_4->raw[ds_4->rawlen-1] <= (MAX_PULSE_LENGTH*PULSE_DIV)) {
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+static void createMessage(int unitcode, int state) {
+	ds_4->message = json_mkobject();
+	json_append_member(ds_4->message, "unitcode", json_mknumber(unitcode, 0));
+	if(state == 14) {
+		json_append_member(ds_4->message, "state", json_mkstring("closed"));
+	} else if(state == 10) {
+		json_append_member(ds_4->message, "state", json_mkstring("opened"));
+	} else if(state == 7) {
+	  json_append_member(ds_4->message, "state", json_mkstring("tampered"));
+	} else {
+	  json_append_member(ds_4->message, "state", json_mknumber(state, 0));
+	}
+}
+
+static void parseCode(void) {
+	int binary[RAW_LENGTH/2], x = 0, i = 0;
+
+	if(ds_4->rawlen>RAW_LENGTH) {
+		logprintf(LOG_ERR, "ds_4: parsecode - invalid parameter passed %d", ds_4->rawlen);
+		return;
+	}
+
+	for(x=0;x<ds_4->rawlen-2;x+=2) {
+		if(ds_4->raw[x] > (int)((double)AVG_PULSE_LENGTH*((double)PULSE_MULTIPLIER/2))) {
+			binary[i++] = 1;
+		} else {
+			binary[i++] = 0;
+		}
+	}
+	
+	int unitcode = binToDecRev(binary, 0, 15);
+	int state = binToDecRev(binary, 20, 23);
+	createMessage(unitcode, state);
+}
+
+#if !defined(MODULE) && !defined(_WIN32)
+__attribute__((weak))
+#endif
+void ds_4Init(void) {
+
+	protocol_register(&ds_4);
+	protocol_set_id(ds_4, "ds_4");
+	protocol_device_add(ds_4, "ds_4", "ds_4 contact sensor");
+	ds_4->devtype = CONTACT;
+	ds_4->hwtype = RF433;
+	ds_4->minrawlen = RAW_LENGTH;
+	ds_4->maxrawlen = RAW_LENGTH;
+	ds_4->maxgaplen = MAX_PULSE_LENGTH*PULSE_DIV;
+	ds_4->mingaplen = MIN_PULSE_LENGTH*PULSE_DIV;
+
+	options_add(&ds_4->options, 'u', "unitcode", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, NULL);
+	options_add(&ds_4->options, 't', "opened", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
+	options_add(&ds_4->options, 'f', "closed", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
+	options_add(&ds_4->options, 't', "tampered", OPTION_NO_VALUE, DEVICES_STATE, JSON_STRING, NULL, NULL);
+
+	ds_4->parseCode=&parseCode;
+	ds_4->validate=&validate;
+}
+
+#if defined(MODULE) && !defined(_WIN32)
+void compatibility(struct module_t *module) {
+	module->name = "ds_4";
+	module->version = "0.1";
+	module->reqversion = "6.0";
+	module->reqcommit = "84";
+}
+
+void init(void) {
+	ds_4Init();
+}
+#endif

--- a/libs/pilight/protocols/433.92/ds_4.h
+++ b/libs/pilight/protocols/433.92/ds_4.h
@@ -1,0 +1,27 @@
+/*
+	Copyright (C) 2017 Torwag
+
+	This file is part of pilight.
+
+	pilight is free software: you can redistribute it and/or modify it under the
+	terms of the GNU General Public License as published by the Free Software
+	Foundation, either version 3 of the License, or (at your option) any later
+	version.
+
+	pilight is distributed in the hope that it will be useful, but WITHOUT ANY
+	WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+	A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with pilight. If not, see	<http://www.gnu.org/licenses/>
+*/
+
+#ifndef _PROTOCOL_DS_4_H_
+#define _PROTOCOL_DS_4_H_
+
+#include "../protocol.h"
+
+struct protocol_t *ds_4;
+void ds_4Init(void);
+
+#endif


### PR DESCRIPTION
First draft of a protocol for magnetic contact sensors obtained from [China](https://www.aliexpress.com/store/product/5pcs-433MHz-EV1527-two-way-wireless-intelligent-door-window-sensor-APP-control-wifi-door-detector-for/725200_32642367411.html).  
The come with a Chinese uC STC15W100, which might help to identify clones of this unit with the same protocol.
The unit claims two-way communication however, that actually means it sends out both events, opening and closing, as well as a tempering event. It also claims low battery but I could not yet figure that out. Each event is send out 15-20 times (did not count). 

The protocol is very similar to the EV1527, yet different enough that I could not add it easily without messing the EV1527 code. 
Hence a new protocol. From Raw mode inspection and testing
```
AW RF signal (50): c:01100101100110010101100101010110101010100110011012;p:1395,446,13999@
 
Sensor 1:
01100101010110011010010110101001101010100101011012 on
01100101010110011010010110101001101010100110011012 off
01100101010110011010010110101001101010101001010112 tamper on & off
01100101010110011010010110101001101010101001010112 tamper on & on
01100101010110011010010110101001101010100101011012 tamper off & on

Sensor2:
01100101100110101001011010100101101010100101011012 on
01100101100110101001011010100101101010100110011012 off

Sensor3:
01100101100110010101100101010110101010100110011012 off

removed the last two pulses (footer) and decode with 10 = 0 and 01 = 1 
results in the following bit codes

10111101 00110001 0000 1110 on sensor 1
10111101 00110001 0000 1010 off sensor 1
10111101 00110001 0000 0111 tamper on & off sensor 1
10111101 00110001 0000 0111 tamper off & on sensor 1
10111101 00110001 0000 1110 tamper off & on
10110100 01100011 0000 1110 on sensor 2
10110100 01100011 0000 1010 off sensor 2
10110101 11011110 0000 1010 off sensor 3

First 16 bit seem to be the unitcode address:
then 4 unused bit (battery?)
followed by 4 data bits in the form tamper on/off 1 tamper 
```
There seems to be no combination, each event sends only the event code without taking care of the state of the other bits. At least that allows for easy binary number checking to identify the event.
Seller claims low battery function, but I could not yet discover this in the datagram.
The PCB of the unit is named DS-4, thus I named the protocol like this. Seller claim it is a sensor working for G90B G90E  alarm systems. As a slightly more known brand Kerui is selling similar sensors. However, I could not yet test the protocol as I do not own a Kerui contact sensor. Changes are high that they are compatible. 

Compilation of pilight is okay, but I could not test it since I  have no hardware. I used a version of the [MQTT433Gateway](https://github.com/puuu/MQTT433gateway), which in turn uses a port of pilight for the esp8266. I tested the patch on the ESP8266 with MQTT433gateway and all events were shown correctly.
Before, there was no event at all, thus I believe the protocol was missing. I was told to submit a protocol patch upstream, to make sure digital cookies are send to those who earned them ;)

This is my first contribution to pilight and hence maybe not in the correct formal order. I am happy to improve the patch or add changes as required.

