### PR TITLE
Python clients: Change license to MPLv2

### DIFF
--- a/clients/process.py
+++ b/clients/process.py
@@ -1,20 +1,9 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2017 CurlyMo and pilino1234
-#
-# This file is part of pilight.
-#
-# pilight is free software: you can redistribute it and/or modify it under the
-# terms of the GNU General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later
-# version.
-#
-# pilight is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with pilight. If not, see	<http://www.gnu.org/licenses/>
+# Copyright (C) 2017 pilino1234
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
 """Example Python 2 client for pilight daemon socket API
@@ -90,8 +79,8 @@ if __name__ == "__main__":
             try:
                 s.connect((location, int(port)))
             except ConnectionRefusedError:
-                        # Connection was refused, try next SSDP response
-#                        print "connection refused"
+                # Connection was refused, try next SSDP response
+                print "connection refused"
                 continue
 
             s.send('{"action": "identify", "options": {"core": 1}}')

--- a/clients/process.py3
+++ b/clients/process.py3
@@ -1,20 +1,9 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2017 curlymo and pilino1234
-#
-# This file is part of pilight.
-#
-# pilight is free software: you can redistribute it and/or modify it under the
-# terms of the GNU General Public License as published by the Free Software
-# Foundation, either version 3 of the License, or (at your option) any later
-# version.
-#
-# pilight is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with pilight. If not, see	<http://www.gnu.org/licenses/>
+# Copyright (C) 2017 pilino1234
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
 """Example Python 3 client for pilight daemon socket API


### PR DESCRIPTION
Also fix indentation and uncomment a print in the python2 version