### PR TITLE
using localtime instead of UTC in the logfile

### DIFF
--- a/libs/pilight/core/log.c
+++ b/libs/pilight/core/log.c
@@ -169,10 +169,10 @@ void logprintf(int prio, const char *format_str, ...) {
 		gettimeofday(&tv, NULL);
 #ifdef _WIN32
 		struct tm *tm1;
-		if((tm1 = gmtime(&tv.tv_sec)) != 0) {
+		if((tm1 = localtime(&tv.tv_sec)) != 0) {
 			memcpy(&tm, tm1, sizeof(struct tm));
 #else
-		if((gmtime_r(&tv.tv_sec, &tm)) != 0) {
+		if((localtime_r(&tv.tv_sec, &tm)) != 0) {
 #endif
 			strftime(fmt, sizeof(fmt), "%b %d %H:%M:%S", &tm);
 			snprintf(buf, sizeof(buf), "%s:%03u", fmt, (unsigned int)tv.tv_usec);


### PR DESCRIPTION
Hi,
in the logfiles pilight.err & pilight.log the timestamp is 2 hours ahead of my systemtime. The datetime protocol dont have this issue...
My raspbian time is set to localtime and in-sync with ntp....

The attached patch changed the timeformat in the logfile to the localtime and is now the same like the systemtime...

Greetz
Marc
