### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+dist: trusty
+sudo: true
+
+cache: ccache
+
+env:
+  matrix:
+    - CONFIG=DEFAULT
+#    - CONFIG=ALL_ON
+#    - CONFIG=ALL_OFF
+
+addons:
+  apt:
+    packages:
+      - libpcap-dev
+      - libunwind8-dev
+
+install:
+  - curl https://apt.pilight.org/pilight.key | sudo apt-key add - && echo "deb http://apt.pilight.org/ stable main" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq && sudo apt-get install libwiringx-dev libwiringx -y
+  - mkdir depends && pushd depends
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedcrypto0_2.2.1-2ubuntu0.1_amd64.deb
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedtls10_2.2.1-2ubuntu0.1_amd64.deb
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedx509-0_2.2.1-2ubuntu0.1_amd64.deb
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedtls-dev_2.2.1-2ubuntu0.1_amd64.deb
+  - sudo dpkg -i *.deb
+  - popd
+
+before_script:
+  - if [[ $CONFIG == "ALL_OFF" ]]; then sed "s/\(set(.*\) ON/\1 OFF/" -i CMakeConfig.txt; fi
+  - if [[ $CONFIG == "ALL_ON" ]]; then sed "s/\(set(.*\) OFF/\1 ON/" -i CMakeConfig.txt; fi
+
+script:
+  - mkdir build && pushd build && cmake .. && make && sudo ./pilight-unittest && sudo make install


### PR DESCRIPTION
This adds a configuration for travis to test the build.

It runs the build using different configuration options in CMakeConfig.txt:

* options kept at default
* all options set to OFF
* all options set to ON

Right now it just tests the build and installation as the unittest hangs at test_arp.

I tested the configuration on https://travis-ci.org/schaal/pilight