### PR TITLE
Fix segfault in event_actions_mail unittests

### DIFF
--- a/tests/event_actions_mail.c
+++ b/tests/event_actions_mail.c
@@ -29,7 +29,6 @@
 
 #include "alltests.h"
 
-static uv_thread_t pth;
 static int steps = 0;
 static int nrsteps = 0;
 static CuTest *gtc = NULL;
@@ -740,8 +739,6 @@ static void test_event_actions_mail_run(CuTest *tc) {
 	protocol_gc();
 	storage_gc();
 	eventpool_gc();
-
-	uv_thread_join(&pth);
 
 	CuAssertIntEquals(tc, 1, check);
 	CuAssertIntEquals(tc, 0, xfree());


### PR DESCRIPTION
Joining no threads causes a segfault, fixed my removing thread joining

Segfault:
```
(gdb) run
Starting program: /home/linoM6400/git/pilight/rewrite/build/pilight-unittest 
Missing separate debuginfos, use: zypper install glibc-debuginfo-2.22-4.9.1.x86_64
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
[ test_event_actions_mail_check_parameters         ]
[ test_event_actions_mail_run                      ]

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff6c65901 in pthread_join () from /lib64/libpthread.so.0
Missing separate debuginfos, use: zypper install libdbus-1-3-debuginfo-1.8.22-3.1.x86_64 libnl3-200-debuginfo-3.2.23-4.5.x86_64 libpcap1-debuginfo-1.8.1-7.3.1.x86_64 libunwind-debuginfo-1.1-12.5.x86_64
(gdb) bt full
#0  0x00007ffff6c65901 in pthread_join () from /lib64/libpthread.so.0
No symbol table info available.
#1  0x00007ffff73c824d in uv_thread_join (tid=0x797bb0 <pth>) at /home/linoM6400/git/pilight/rewrite/libs/libuv/unix/thread.c:89
No locals.
#2  0x0000000000420b9f in test_event_actions_mail_run (tc=0x7b01f0) at /home/linoM6400/git/pilight/rewrite/tests/event_actions_mail.c:744
        __FUNCTION__ = "test_event_actions_mail_run"
        f = 0x7ba110
#3  0x00007ffff73e13f3 in CuTestRun (tc=0x7b01f0) at /home/linoM6400/git/pilight/rewrite/libs/pilight/core/CuTest.c:143
        buf = {{__jmpbuf = {0, -7676778627216066290, 4231168, 140737488350256, 0, 0, 7676778626747578638, 7676795679181224206}, __mask_was_saved = 0, __saved_mask = {__val = {140737351976608, 4231168, 140737341045872, 0, 0, 4231168, 140737351976608, 140737488350256, 
                140737341428456, 8061312, 8061424, 0, 8061424, 8061312, 3, 140737319634552}}}}
#4  0x00007ffff73e1a7f in CuSuiteRun (testSuite=0x7ac140) at /home/linoM6400/git/pilight/rewrite/libs/pilight/core/CuTest.c:298
        testCase = 0x7b01f0
        i = 1
#5  0x00000000004091ee in RunAllTests () at /home/linoM6400/git/pilight/rewrite/tests/alltests.c:171
        i = 1
        pth_cur_id = 140737353856832
        r = 0
#6  0x0000000000409305 in main (argc=1, argv=0x7fffffffec38) at /home/linoM6400/git/pilight/rewrite/tests/alltests.c:194
        f = 0x7ac010
```