### PR TITLE
logging: Always pad timestamp to same length

### DIFF
--- a/libs/pilight/core/log.c
+++ b/libs/pilight/core/log.c
@@ -185,7 +185,7 @@ void logprintf(int prio, const char *format_str, ...) {
 		if((gmtime_r(&tv.tv_sec, &tm)) != 0) {
 #endif
 			strftime(fmt, sizeof(fmt), "%b %d %H:%M:%S", &tm);
-			snprintf(buf, sizeof(buf), "%s:%03u", fmt, (unsigned int)tv.tv_usec);
+			snprintf(buf, sizeof(buf), "%s:%06ld", fmt, tv.tv_usec);
 		}
 		pos += sprintf(line, "[%22.22s] %s: ", buf, progname);
 


### PR DESCRIPTION
This fixes inconsistent looking timestamps in the logging output by always
padding the microsecond component to 6 digits

Before:
```
[Sep 05 10:57:08:925516] pilight-daemon: DEBUG: new thread events loop, 6 threads running
[Sep 05 10:57:08:925549] pilight-daemon: DEBUG: ssdp sent search
[ Sep 05 10:57:09:24103] pilight-daemon: NOTICE: no pilight ssdp connections found
[ Sep 05 10:57:09:24359] pilight-daemon: INFO: new client, ip: 127.0.0.1, port: 55554
[ Sep 05 10:57:09:24383] pilight-daemon: DEBUG: client fd: 14
[ Sep 05 10:57:09:24384] pilight-daemon: DEBUG: socket write succeeded: {"action":"identify","options":{"config":1,"receiver":1},"media":"all"}

[ Sep 05 10:57:09:24411] pilight-daemon: DEBUG: client id: 2
[ Sep 05 10:57:09:24496] pilight-daemon: DEBUG: socket recv: {"action":"identify","options":{"config":1,"receiver":1},"media":"all"}
[ Sep 05 10:57:09:24565] pilight-daemon: DEBUG: socket write succeeded: {"status":"success"}

[Sep 05 10:57:09:918528] pilight-daemon: DEBUG: cpu: 0.000000%
[Sep 05 10:57:12:921150] pilight-daemon: DEBUG: cpu: 0.027052%
```

After:
```
[Sep 05 10:59:39:445397] pilight-daemon: DEBUG: new client, ip: 127.0.0.1, port: 35082
[Sep 05 10:59:39:445407] pilight-daemon: DEBUG: client fd: 55
[Sep 05 10:59:39:445468] pilight-daemon: DEBUG: new client, ip: 127.0.0.1, port: 35084
[Sep 05 10:59:39:445479] pilight-daemon: DEBUG: client fd: 56
[Sep 05 10:59:39:445532] pilight-daemon: DEBUG: new client, ip: 127.0.0.1, port: 35086
[Sep 05 10:59:39:445542] pilight-daemon: DEBUG: client fd: 57
[Sep 05 10:59:39:445598] pilight-daemon: DEBUG: new client, ip: 127.0.0.1, port: 35088
[Sep 05 10:59:39:445608] pilight-daemon: DEBUG: client fd: 58
[Sep 05 10:59:39:624493] pilight-daemon: DEBUG: cpu: 0.208244%
[Sep 05 10:59:39:956868] pilight-daemon: DEBUG: new client, ip: 127.0.0.1, port: 35090
[Sep 05 10:59:39:956899] pilight-daemon: DEBUG: client fd: 55
[Sep 05 10:59:40:024723] pilight-daemon: DEBUG: new client, ip: 127.0.0.1, port: 35092
[Sep 05 10:59:40:024750] pilight-daemon: DEBUG: client fd: 55
[Sep 05 10:59:40:032376] pilight-daemon: DEBUG: socket recv: {"action":"request config"}
[Sep 05 10:59:40:038319] pilight-daemon: DEBUG: socket recv: {"action":"request values"}
[Sep 05 10:59:42:624590] pilight-daemon: DEBUG: cpu: 0.067852%
```