### PR TITLE
Update travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ install:
   - curl https://apt.pilight.org/pilight.key | sudo apt-key add - && echo "deb http://apt.pilight.org/ stable main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq && sudo apt-get install libwiringx-dev libwiringx -y
   - mkdir depends && pushd depends
-  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedcrypto0_2.2.1-2ubuntu0.1_amd64.deb
-  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedtls10_2.2.1-2ubuntu0.1_amd64.deb
-  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedx509-0_2.2.1-2ubuntu0.1_amd64.deb
-  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedtls-dev_2.2.1-2ubuntu0.1_amd64.deb
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedcrypto0_2.5.1-1ubuntu1_amd64.deb
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedtls10_2.5.1-1ubuntu1_amd64.deb
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedx509-0_2.5.1-1ubuntu1_amd64.deb
+  - wget http://security.ubuntu.com/ubuntu/pool/universe/m/mbedtls/libmbedtls-dev_2.5.1-1ubuntu1_amd64.deb
   - sudo dpkg -i *.deb
   - popd
 


### PR DESCRIPTION
Travis builds are failing because the packages in the ubuntu repos have been updated.