### PR TITLE
Break long switch caption in multiple lines

### DIFF
--- a/libs/webgui/pilight.css
+++ b/libs/webgui/pilight.css
@@ -344,3 +344,13 @@ div.media_icon.episode {
 div.media_icon.song {
 	background: url('song.png') 0px 0px no-repeat;
 }
+
+ul.ui-listview li.switch div.name {
+        padding-right: 95px;
+        white-space: normal;
+}
+
+.ui-li-static {
+        height: auto;
+        min-height: 27px;
+}


### PR DESCRIPTION
This is a small css modification to allow long captions of switches to break into multiple lines.

![snap_2017 10 02 10 43 51_001](https://user-images.githubusercontent.com/3126577/31069923-c36f031c-a75e-11e7-8b17-ec590d76f5d5.png)
