### PR TITLE
Added manual page for secudo protocol

### DIFF
--- a/docs/source/protocols/433.92/alarm/secudo.rst
+++ b/docs/source/protocols/433.92/alarm/secudo.rst
@@ -1,0 +1,115 @@
+.. |yes| image:: ../../../images/yes.png
+.. |no| image:: ../../../images/no.png
+
+.. role:: underline
+   :class: underline
+
+Secudo
+======
+
++------------------+-------------+
+| **Feature**      | **Support** |
++------------------+-------------+
+| Sending          | |no|        |
++------------------+-------------+
+| Receiving        | |yes|       |
++------------------+-------------+
+| Config           | |yes|       |
++------------------+-------------+
+
+.. rubric:: Supported Brands
+
++-----------------------+----------------+
+| **Brand**             | **Protocol**   |
++-----------------------+----------------+
+| Secudo                | secudo         |
++-----------------------+----------------+
+| FlammEx               | secudo         |
++-----------------------+----------------+
+
+.. rubric:: Sender Arguments
+
+*None*
+
+.. rubric:: Config
+
+.. code-block:: json
+   :linenos:
+
+   {
+     "devices": {
+       "alarm": {
+         "protocol": [ "secudo" ],
+         "id": [{
+           "id": 493
+         }],
+         "state": "alarm"
+       }
+     }
+   }
+
++------------------+-----------------+
+| **Option**       | **Value**       |
++------------------+-----------------+
+| id               | 0 - 1023        |
++------------------+-----------------+
+| state            | alarm           |
++------------------+-----------------+
+
+.. rubric:: Optional Settings
+
+*None*
+
+.. rubric:: Protocol
+
+This protocol sends 26 pulses like this:
+
+.. code-block:: console
+
+   314 314 628 628 314 314 628 314 628 628 314 314 628 314 628 314 628 314 628 628 314 628 314 314 628 10676
+
+The first pulse is the ``header`` and the last pulse is the ``footer``.
+These are meant to identify the pulses as genuine.
+We don't use them for further processing.
+The next step is to transform the remaining pulses into 12 groups of two pulses (and thereby dropping the ``header`` and ``footer`` pulses):
+
+.. code-block:: guess
+
+   314 628
+   628 314
+   314 628
+   314 628
+   628 314
+   314 628
+   314 628
+   314 628
+   314 628
+   628 314
+   628 314
+   314 628
+
+If we now look carefully at these groups you can distinguish two types of groups:
+
+#. 314 628
+#. 628 314
+
+So the first group is defined by a high 2nd and the second group by a high 1st pulse.
+So we take either of these two pulses to define a 0 or a 1.
+In this case we say a high 2nd pulse means a 1 and a low 2nd pulse means a 0.
+We then get the following output:
+
+.. code-block:: guess
+
+   101101111001
+
+The first 10 bits correspond to the setting of the ten dip switches inside the smoke sensor.
+If a dip switch is ON, this corresponds to 1 and 0 otherwise.
+The meaning of the two last bits is unknown.
+When reversing the first 10 bits because the first bits are least signifant we get the smoke sensors ID as binary number
+
+.. code-block:: guess
+
+   0111101101
+
+which is 493 as decimal number.
+This means that the 2nd, 5th and 10th dip switch is OFF and all others are ON.


### PR DESCRIPTION
I added a manual page for the secudo protocol and created a pull request.
I created it by using another manual page as template and changing things to the best of my knowledge.
However, I'm not sure about the config stuff contained in the manual page.
The smoke sensors simply send repeatedly a signal if they detect smoke or the test button is pressed which will generate repeatedly corresponding messages in pilight's JSON output with the code changes of commit 91ffcb3.
I personally do not use pilight's gui and have not defined anything for the smoke sensors in the pilight configuration because I only use pilight's JSON output.
I don't know if there is any reasonable output in the gui if one defines such a smoke sensor in pilight's configuration.
