### PR TITLE
Update arctech_switch.c to be compatible with smartwares switches

### DIFF
--- a/libs/pilight/protocols/433.92/arctech_switch.c
+++ b/libs/pilight/protocols/433.92/arctech_switch.c
@@ -121,7 +121,7 @@ static void clearCode(void) {
 
 static void createStart(void) {
 	arctech_switch->raw[0]=(AVG_PULSE_LENGTH);
-	arctech_switch->raw[1]=(9*AVG_PULSE_LENGTH);
+	arctech_switch->raw[1]=(8*AVG_PULSE_LENGTH);
 }
 
 static void createId(int id) {


### PR DESCRIPTION
As discussed here:
https://forum.pilight.org/Thread-Smartwares-SHS-53000-radiator-valve?pid=21766#pid21766
Change pulse length for second start pulse from 9* to 8*
