### PR TITLE
Fix issue with too small dimmer controls

### DIFF
--- a/libs/webgui/pilight.css
+++ b/libs/webgui/pilight.css
@@ -40,7 +40,7 @@
 }
 
 .ui-li-static {
-	height: 27px;
+	min-height: 27px;
 	padding: 5px 0px 5px 0px;
 }
 
@@ -352,9 +352,4 @@ div.media_icon.song {
 ul.ui-listview li.switch div.name {
         padding-right: 95px;
         white-space: normal;
-}
-
-.ui-li-static {
-        height: auto;
-        min-height: 27px;
 }


### PR DESCRIPTION
This fixes the issue with dimmer controls being not high enough reported here:
https://github.com/pilight/pilight/commit/892289638dfa4edb6934e4c05a6bcb3ca16ad3ec#commitcomment-25587958