### PR TITLE
Break up long label text into multiple lines

### DIFF
--- a/libs/webgui/pilight.css
+++ b/libs/webgui/pilight.css
@@ -130,7 +130,7 @@ div.ui-slider-switch, div.screen {
 }
 
 li.label .text {
-	position: absolute;
+	position: relative;
 	right: 0px;
 	margin: 2px 5px 0px 5px;
 	color: black;
@@ -143,10 +143,10 @@ li.label .marquee {
 	overflow: hidden;
 	font-weight: normal;
 	text-align: right;
-	width: 50%;
+	max-width: 95%;
 	padding: 4px 5px 0px 5px;
-	white-space: nowrap;
-	height: 25px;
+	white-space: normal;
+	min-height: 25px;
 	-moz-border-radius: 4px 4px 4px 4px;
 	border-radius: 4px 4px 4px 4px;
 }


### PR DESCRIPTION
Currently a label text, longer than 50% of the available width, is only partially visible.

With this commit a label text is allowed to use 95% of the available width and wrap around if it is even longer. 
This ensures that label text is always completely  visible, also on narrow screens.