### PR TITLE
Added (optional) blink feature to generic_label

### DIFF
--- a/docs/source/eventing/actions/label.rst
+++ b/docs/source/eventing/actions/label.rst
@@ -20,9 +20,11 @@ Changes the text and color of a generic label device.
 +----------+------------------+---------------------+---------------------------------------------------+
 | TO       | |yes|            | |no|                | New text                                          |
 +----------+------------------+---------------------+---------------------------------------------------+
-| COLOR    | |no|             | |no|                | New color. If omitted, color is set to black"     |
-+----------+------------------+---------------------+---------------------------------------------------+
 | **Name** | **Required**     | **Multiple Values** | **Description**                                   |
++----------+------------------+---------------------+---------------------------------------------------+
+| COLOR    | |no|             | |no|                | New color                                         |
++----------+------------------+---------------------+---------------------------------------------------+
+| BLINK    | |no|             | |no|                | Blinking on or off                                |
 +----------+------------------+---------------------+---------------------------------------------------+
 | FOR      | |no|             | |no|                | | Determine how long this new label lasts         |
 |          |                  |                     | | before we change back to the previous label     |
@@ -30,7 +32,13 @@ Changes the text and color of a generic label device.
 | AFTER    | |no|             | |no|                | After how long do we want the new label to be set |
 +----------+------------------+---------------------+---------------------------------------------------+
 
-.. note:: Units for ``FOR`` and ``AFTER``
+.. note:: 1. Valid values for ``BLINK``
+
+   - on
+   - off
+
+
+2. Units for ``FOR`` and ``AFTER``
 
    - MILLISECOND
    - SECOND
@@ -47,3 +55,4 @@ Changes the text and color of a generic label device.
    IF 1 == 1 THEN label DEVICE tempLabel TO 23.5 FOR 10 SECOND
    IF 1 == 1 THEN label DEVICE tempLabel TO Bell rang AFTER 30 SECOND
    IF 1 == 1 THEN label DEVICE tempLabel TO None FOR 10 MINUTE AFTER 30 SECOND
+   IF 1 == 1 THEN label DEVICE tempLabel TO Door was opened BLINK on FOR 1 MINUTE

--- a/docs/source/protocols/generic/label.rst
+++ b/docs/source/protocols/generic/label.rst
@@ -28,6 +28,8 @@ Label
    -i --id=id               control a device with this id
    -l --label=label         show a specific label
    -c --color=color         give the label a specific color
+   -b --blink=on|off        enable or disable blinking of the label
+
 
 .. rubric:: Config
 
@@ -42,7 +44,8 @@ Label
            "id": 100
          }],
          "label": "test1234",
-         "color": "red"
+         "color": "red",
+         "blink": "off"
        }
      },
      "gui": {
@@ -63,7 +66,11 @@ Label
 +------------------+-----------------+
 | color            | *any color*     |
 +------------------+-----------------+
+| blink            | "on" or "off    |
++------------------+-----------------+
 
 .. note::
 
    Please notice that the label color is not validated in any way. The color information is just forwarded to the GUIs as is. So it could be that some GUIs do not support certain color naming. Using hex colors is therefore the safest, e.g. #000000.
+
+   The blink option is optional, but must be configured if blinking of the label is desired.

--- a/libs/pilight/protocols/generic/generic_label.c
+++ b/libs/pilight/protocols/generic/generic_label.c
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2015 CurlyMo
+	Copyright (C) 2015 - 2017 CurlyMo & Niek
 
 	This file is part of pilight.
 
@@ -30,22 +30,24 @@
 #include "../../core/gc.h"
 #include "generic_label.h"
 
-static void createMessage(int id, char *label, char *color) {
+static void createMessage(int id, char *label, char *color, char *blink) {
 	generic_label->message = json_mkobject();
 	json_append_member(generic_label->message, "id", json_mknumber(id, 0));
 	json_append_member(generic_label->message, "label", json_mkstring(label));
 	json_append_member(generic_label->message, "color", json_mkstring(color));
+	if(blink != NULL) {
+		json_append_member(generic_label->message, "blink", json_mkstring(blink));
+	}
 }
 
 static int createCode(JsonNode *code) {
-	int id = -1, free_label = 0;
-	char *label = NULL;
-	char *color = "black";
+	char *label = NULL, *color = "black", *blink = NULL;
 	double itmp = 0;
+	int id = -1, free_label = 0;
 
-	if(json_find_number(code, "id", &itmp) == 0)
+	if(json_find_number(code, "id", &itmp) == 0) {
 		id = (int)round(itmp);
-
+	}
 	json_find_string(code, "label", &label);
 	if(json_find_number(code, "label", &itmp) == 0) {
 		if((label = MALLOC(BUFFER_SIZE)) == NULL) {
@@ -56,25 +58,25 @@ static int createCode(JsonNode *code) {
 		snprintf(label, BUFFER_SIZE, "%d", (int)itmp);
 	}
 	json_find_string(code, "color", &color);
+	json_find_string(code, "blink", &blink);
 
 	if(id == -1 || label == NULL) {
 		logprintf(LOG_ERR, "generic_label: insufficient number of arguments");
 		return EXIT_FAILURE;
 	} else {
-		createMessage(id, label, color);
+		createMessage(id, label, color, blink);
 	}
 	if(free_label) {
 		FREE(label);
 	}
-
 	return EXIT_SUCCESS;
-
 }
 
 static void printHelp(void) {
 	printf("\t -i --id=id\t\t\tcontrol a device with this id\n");
 	printf("\t -l --label=label\t\tset this label\n");
 	printf("\t -c --color=color\t\tset label color\n");
+	printf("\t -b --blink=on|off\t\tset blinking state of this label\n");
 }
 
 #if !defined(MODULE) && !defined(_WIN32)
@@ -90,6 +92,7 @@ void genericLabelInit(void) {
 	options_add(&generic_label->options, 'i', "id", OPTION_HAS_VALUE, DEVICES_ID, JSON_NUMBER, NULL, "^([0-9]{1,})$");
 	options_add(&generic_label->options, 'l', "label", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING | JSON_NUMBER, NULL, NULL);
 	options_add(&generic_label->options, 'c', "color", OPTION_HAS_VALUE, DEVICES_VALUE, JSON_STRING, NULL, NULL);
+	options_add(&generic_label->options, 'b', "blink", OPTION_HAS_VALUE, DEVICES_OPTIONAL, JSON_STRING, NULL, "^{on, off}$");
 
 	generic_label->printHelp=&printHelp;
 	generic_label->createCode=&createCode;
@@ -98,7 +101,7 @@ void genericLabelInit(void) {
 #if defined(MODULE) && !defined(_WIN32)
 void compatibility(struct module_t *module) {
 	module->name = "generic_label";
-	module->version = "1.2";
+	module->version = "1.3";
 	module->reqversion = "6.0";
 	module->reqcommit = "84";
 }

--- a/libs/webgui/pilight.css
+++ b/libs/webgui/pilight.css
@@ -129,11 +129,26 @@ div.ui-slider-switch, div.screen {
 	right: 10px;
 }
 
+@keyframes blink {
+	0% { opacity: 1; }
+	50% { opacity: 1; }
+	50.01% { opacity: 0; }
+	100% { opacity: 0; }
+}
+
+@keyframes none {
+	0% { opacity: 1; }
+}
+ 
 li.label .text {
 	position: relative;
 	right: 0px;
-	margin: 2px 5px 0px 5px;
 	color: black;
+	margin: 2px 5px 0px 5px;
+	animation-name: none;
+	animation-duration: .75s;
+	animation-timing-function: linear;
+	animation-iteration-count: infinite;
 }
 
 li.label .marquee {

--- a/libs/webgui/pilight.js
+++ b/libs/webgui/pilight.js
@@ -215,6 +215,9 @@ function createLabelElement(sTabId, sDevId, aValues) {
 		if('name' in aValues) {
 			oTab.append($('<li id="'+sDevId+'" class="label" data-icon="false"><div class="name">'+aValues['name']+'</div><div class="marquee"><div class="text">'+aValues['label']+'</div></div></li>'));
 			$('#'+sDevId+' div.marquee .text').css('color', aValues['color']);
+			if(aValues['blink'] == 'on') {
+				$('#'+sDevId+' div.marquee .text').css('animation-name', 'blink');
+			}
 			// var mar = $('#'+sDevId+' div.marquee .text');
 			// var left = -(mar.width()+3);
 			// var ori = left;
@@ -1133,6 +1136,12 @@ function parseValues(data) {
 						$('#'+dvalues+' div.marquee .text').text(vvalues);
 					} else if(vindex == 'color') {
 						$('#'+dvalues+' div.marquee .text').css('color', vvalues);
+					} else if(vindex == 'blink') {
+						if(vvalues == 'on') {
+							$('#'+dvalues+' div.marquee .text').css('animation-name', 'blink');
+						} else {
+							$('#'+dvalues+' div.marquee .text').css('animation-name', 'none');
+						}						
 					}
 				}
 			});


### PR DESCRIPTION
Generic_label devices with the BLINK option configured, can be set
to blinking/not blinking  with the label action.
This commit includes:
- generic_label protocol  with BLINK option + documentation
- label action with BLINK option + documentation
- pilight.css with additions defining blink properties
- pilight.js with additions to reflect blinking/not blinking state in the webgui