### PR TITLE
Fix segfault in isrunning() on encountering long process name

### DIFF
--- a/libs/pilight/core/common.c
+++ b/libs/pilight/core/common.c
@@ -234,11 +234,11 @@ int isrunning(const char *program) {
 		return -1;
 	}
 	int i = 0;
-	char name[255], *p = name;
-	memset(&name, '\0', 255);
+	char name[1024], *p = name;
+	memset(&name, '\0', sizeof(name));
 
 	for(i=0;i<psutil_max_pid();i++) {
-		if(psutil_proc_name(i, &p) == 0) {
+		if(psutil_proc_name(i, &p, sizeof(name)) == 0) {
 			if(strcmp(name, program) == 0) {
 				return i;
 			}

--- a/libs/pilight/psutil/freebsd.c
+++ b/libs/pilight/psutil/freebsd.c
@@ -35,7 +35,7 @@ int psutil_proc_exe(const pid_t pid, char **name) {
 	return 0;
 }
 
-int psutil_proc_name(const pid_t pid, char **name) {
+int psutil_proc_name(const pid_t pid, char **name, size_t bufsize) {
 	// Fills a kinfo_proc struct based on process pid.
 	struct kinfo_proc proc;
 	int mib[4];

--- a/libs/pilight/psutil/linux.c
+++ b/libs/pilight/psutil/linux.c
@@ -43,9 +43,9 @@ int psutil_proc_exe(const pid_t pid, char **name) {
 	return -1;
 }
 
-int psutil_proc_name(const pid_t pid, char **name) {
+int psutil_proc_name(const pid_t pid, char **name, size_t bufsize) {
 	int ptr = 0, fd = 0;
-	char path[512], *p = path, cmdline[1024];
+	char path[512], *p = path, cmdline[bufsize];
 
 	snprintf(p, 511, "/proc/%d/cmdline", pid);
 	fd = open(path, O_RDONLY, 0);
@@ -53,7 +53,7 @@ int psutil_proc_name(const pid_t pid, char **name) {
 		return -1;
 	}
 
-	if((ptr = (int)read(fd, cmdline, 1023)) > 0) {
+	if((ptr = (int)read(fd, cmdline, bufsize-1)) > 0) {
 		strcpy(*name, basename(cmdline));
 		close(fd);
 		return 0;

--- a/libs/pilight/psutil/psutil.h
+++ b/libs/pilight/psutil/psutil.h
@@ -4,6 +4,6 @@
 
 unsigned long psutil_max_pid(void);
 int psutil_proc_exe(const pid_t pid, char **name);
-int psutil_proc_name(const pid_t pid, char **name);
+int psutil_proc_name(const pid_t pid, char **name, size_t bufsize);
 int psutil_cpu_count_phys(void);
 size_t psutil_get_cmd_args(pid_t pid, char **args, size_t size);

--- a/libs/pilight/psutil/windows.c
+++ b/libs/pilight/psutil/windows.c
@@ -95,7 +95,7 @@ int psutil_proc_exe(const pid_t pid, char **name) {
 	return 0;
 }
 
-int psutil_proc_name(const pid_t pid, char **name) {
+int psutil_proc_name(const pid_t pid, char **name, size_t bufsize) {
 	if((pid % 4) != 0) {
 		return -1;
 	}


### PR DESCRIPTION
Running the slack desktop app while running the unittests revealed that the
process name was too long for the function to store in a char array of size
255. Fixed by increasing the size of the array to 1023, which seems to work
so far.