### PR TITLE
fixed systemd service

### DIFF
--- a/res/init/pilight.systemd
+++ b/res/init/pilight.systemd
@@ -1,6 +1,6 @@
 [Unit]
 Description=pilight
-After=network-online.target
+Requires=network-online.target
 
 [Service]
 ExecStart=/usr/local/sbin/pilight-daemon
@@ -8,4 +8,3 @@ Type=forking
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
changed keyword "After" to "Requires" network-online.target
with only "After" this service will not start correctly after reboot