### PR TITLE
logging: Always pad timestamp to same length (rewrite)

### DIFF
--- a/libs/pilight/core/log.c
+++ b/libs/pilight/core/log.c
@@ -149,17 +149,17 @@ void _logprintf(int prio, char *file, int line, const char *str, ...) {
 			strftime(fmt, sizeof(fmt), "%b %d %H:%M:%S", &tm);
 #endif
 		}
-		len = snprintf(NULL, 0, "(%s #%d) [%s:%03u]", file, line, fmt, (unsigned int)tv.tv_usec);
-		
+
 		/* len + loglevel */
-		// if(len+9 > bufsize) {
+		//len = snprintf(NULL, 0, "(%s #%d) [%s:%03u]", file, line, fmt, (unsigned int)tv.tv_usec);
+        // if(len+9 > bufsize) {
 			// if((buffer = REALLOC(buffer, len+10)) == NULL) {
 				// printf("out of memory\n");
 				// exit(EXIT_FAILURE);
 			// }
 			// bufsize = len+10+1;
 		// }
-		pos += snprintf(buffer, bufsize, "(%s #%d) [%s:%03u] ", file, line, fmt, (unsigned int)tv.tv_usec);
+		pos += snprintf(buffer, bufsize, "(%s #%d) [%s:%06ld] ", file, line, fmt, tv.tv_usec);
 
 		switch(prio) {
 			case LOG_WARNING:
@@ -500,7 +500,7 @@ void logerror(const char *format_str, ...) {
 		strftime(fmt, sizeof(fmt), "%b %d %H:%M:%S", &tm);
 #endif
 		strftime(fmt, sizeof(fmt), "%b %d %H:%M:%S", &tm);
-		snprintf(buf, sizeof(buf), "%s:%03u", fmt, (unsigned int)tv.tv_usec);
+		snprintf(buf, sizeof(buf), "%s:%06ld", fmt, tv.tv_usec);
 	}
 
 	sprintf(date, "[%22.22s] %s: ", buf, progname);


### PR DESCRIPTION
This fixes inconsistent looking timestamps in the logging output by always
padding the microsecond component to 6 digits