### PR TITLE
binary.c: fix handling of s=0 in BITS_MSB_FIRST_TO_VALUE()

### DIFF
--- a/libs/pilight/core/binary.c
+++ b/libs/pilight/core/binary.c
@@ -28,8 +28,9 @@
 #define BITS_MSB_FIRST_TO_VALUE(bits, s, e, result)	\
 	unsigned long long mask = 1;			\
 	result = 0;					\
-	for(; e > 0 && s<=e; mask <<= 1)				\
-		if(bits[e--] != 0)			\
+	e++;						\
+	for(; e > 0 && s<e; mask <<= 1)			\
+		if(bits[--e] != 0)			\
 			result |= mask
 
 #define VALUE_TO_BITS_MSB_FIRST(value, bits, length)	\


### PR DESCRIPTION
This fix a bug introduced with 5eb10328acfd740570d00825c33f656b9591cc86.

`s` can be 0  as by the coment of `binToDecRev()`: [`0<=s<=e`](https://github.com/pilight/pilight/blob/development/libs/pilight/core/binary.c#L54)

This affect the quigg_gt9000 protocol, as it calls [`binToDecRev()` with `s=0`](https://github.com/pilight/pilight/blob/development/libs/pilight/protocols/433.92/quigg_gt9000.c#L161)

Results of `binToDecRev(binToDecRev((int[]){1,1,1,1, 1,1,1,1}, 0, 7))`:
before 5eb10328acfd740570d00825c33f656b9591cc86: 255
after 5eb10328acfd740570d00825c33f656b9591cc86: 127
this patch: 255