### PR TITLE
fix handling of s=0 in BITS_MSB_FIRST_TO_VALUE() for rewrite

### DIFF
--- a/libs/pilight/core/binary.c
+++ b/libs/pilight/core/binary.c
@@ -28,8 +28,9 @@
 #define BITS_MSB_FIRST_TO_VALUE(bits, s, e, result)	\
 	unsigned long long mask = 1;			\
 	result = 0;					\
-	for(; e > 0 && s<=e; mask <<= 1)				\
-		if(bits[e--] != 0)			\
+	e++;						\
+	for(; e > 0 && s<e; mask <<= 1)			\
+		if(bits[--e] != 0)			\
 			result |= mask
 
 #define VALUE_TO_BITS_MSB_FIRST(value, bits, length)	\

--- a/tests/binary.c
+++ b/tests/binary.c
@@ -35,6 +35,20 @@ static void test_binary(CuTest *tc) {
 	CuAssertIntEquals(tc, 42, binToDec(binary, 0, 5));
 	CuAssertIntEquals(tc, 42, binToDec(binary, 0, 6));
 	CuAssertIntEquals(tc, 170, binToDec(binary, 0, 7));
+	CuAssertIntEquals(tc, 1, binToDec(binary, 1, 1));
+	CuAssertIntEquals(tc, 1, binToDec(binary, 1, 2));
+	CuAssertIntEquals(tc, 5, binToDec(binary, 1, 3));
+	CuAssertIntEquals(tc, 5, binToDec(binary, 1, 4));
+	CuAssertIntEquals(tc, 21, binToDec(binary, 1, 5));
+	CuAssertIntEquals(tc, 21, binToDec(binary, 1, 6));
+	CuAssertIntEquals(tc, 85, binToDec(binary, 1, 7));
+	CuAssertIntEquals(tc, 1, binToDec(binary+1, 0, 0));
+	CuAssertIntEquals(tc, 1, binToDec(binary+1, 0, 1));
+	CuAssertIntEquals(tc, 5, binToDec(binary+1, 0, 2));
+	CuAssertIntEquals(tc, 5, binToDec(binary+1, 0, 3));
+	CuAssertIntEquals(tc, 21, binToDec(binary+1, 0, 4));
+	CuAssertIntEquals(tc, 21, binToDec(binary+1, 0, 5));
+	CuAssertIntEquals(tc, 85, binToDec(binary+1, 0, 6));
 
 	CuAssertIntEquals(tc, 0, binToDecRev(binary, 0, 0));
 	CuAssertIntEquals(tc, 1, binToDecRev(binary, 0, 1));
@@ -44,6 +58,20 @@ static void test_binary(CuTest *tc) {
 	CuAssertIntEquals(tc, 21, binToDecRev(binary, 0, 5));
 	CuAssertIntEquals(tc, 42, binToDecRev(binary, 0, 6));
 	CuAssertIntEquals(tc, 85, binToDecRev(binary, 0, 7));
+	CuAssertIntEquals(tc, 1, binToDecRev(binary, 1, 1));
+	CuAssertIntEquals(tc, 2, binToDecRev(binary, 1, 2));
+	CuAssertIntEquals(tc, 5, binToDecRev(binary, 1, 3));
+	CuAssertIntEquals(tc, 10, binToDecRev(binary, 1, 4));
+	CuAssertIntEquals(tc, 21, binToDecRev(binary, 1, 5));
+	CuAssertIntEquals(tc, 42, binToDecRev(binary, 1, 6));
+	CuAssertIntEquals(tc, 85, binToDecRev(binary, 1, 7));
+	CuAssertIntEquals(tc, 1, binToDecRev(binary+1, 0, 0));
+	CuAssertIntEquals(tc, 2, binToDecRev(binary+1, 0, 1));
+	CuAssertIntEquals(tc, 5, binToDecRev(binary+1, 0, 2));
+	CuAssertIntEquals(tc, 10, binToDecRev(binary+1, 0, 3));
+	CuAssertIntEquals(tc, 21, binToDecRev(binary+1, 0, 4));
+	CuAssertIntEquals(tc, 42, binToDecRev(binary+1, 0, 5));
+	CuAssertIntEquals(tc, 85, binToDecRev(binary+1, 0, 6));
 
 	CuAssertIntEquals(tc, 4, decToBin(31, out));
 	for(i=0;i<5;i++) {
@@ -68,7 +96,7 @@ static void test_binary(CuTest *tc) {
 		binary[i] = i % 2 == 0;
 	}
 	CuAssertULongEquals(tc, 6148914691236517205, binToDecUl(binary, 0, 63));
-	CuAssertULongEquals(tc, 3074457345618258602, binToDecRevUl(binary, 0, 63));
+	CuAssertULongEquals(tc, 12297829382473034410U, binToDecRevUl(binary, 0, 63));
 
 	CuAssertULongEquals(tc, 63, decToBinUl(12297829382473034410U, binary));
 


### PR DESCRIPTION
Alternative pr for #408 against rewrite branch and with unit tests.

The patch differs from #408 to make `BITS_MSB_FIRST_TO_VALUE()` compatible with unsigned `e`, as in `binToDecRevUl()`.

If some or all commits should be merge, please ask for it.