### PR TITLE
Additional unittest for str_replace

### DIFF
--- a/libs/pilight/core/common.c
+++ b/libs/pilight/core/common.c
@@ -795,11 +795,10 @@ int str_replace(char *search, char *replace, char **str) {
 			match = 1;
 			int rpos = (x + (slen - rlen));
 			if(rpos < 0) {
-				slen -= rpos;
 				rpos = 0;
 			}
 			nlen = len - (slen - rlen);
-			if(len < nlen) {
+			if(slen < rlen) {
 				if(((*str) = REALLOC((*str), (size_t)nlen+1)) == NULL) { /*LCOV_EXCL_LINE*/
 					OUT_OF_MEMORY /*LCOV_EXCL_LINE*/
 				}

--- a/tests/common.c
+++ b/tests/common.c
@@ -515,6 +515,16 @@ static void test_str_replace(CuTest *tc) {
 	CuAssertIntEquals(tc, 19, n);
 	CuAssertStrEquals(tc, "<body text='black'>", str);
 
+	strcpy(str, "Apple");
+	n = str_replace("Apple", "Pineapple", &p);
+	CuAssertIntEquals(tc, 9, n);
+	CuAssertStrEquals(tc, "Pineapple", str);
+
+	strcpy(str, "My fruit");
+	n = str_replace("fruit", "raspberry", &p);
+	CuAssertIntEquals(tc, 12, n);
+	CuAssertStrEquals(tc, "My raspberry", str);
+
 	CuAssertIntEquals(tc, 0, xfree());
 }
 


### PR DESCRIPTION
Added two tests demonstrating a bug in str_replace, causing a wrong new length.
This occurs if:

- The replacement string is longer than the search string and
- The offset of the search string found in the target string is lower than the length of the replacement string minus the length of the search string.