### PR TITLE
Fixed number of readed bits in alecto_wx500.c

### DIFF
--- a/libs/pilight/protocols/433.92/alecto_wx500.c
+++ b/libs/pilight/protocols/433.92/alecto_wx500.c
@@ -83,7 +83,7 @@ static void parseCode(void) {
 		}
 	}
 
-	n8=binToDec(binary, 32, 36);
+	n8=binToDec(binary, 32, 35);
 	n7=binToDec(binary, 28, 31);
 	n6=binToDec(binary, 24, 27);
 	n5=binToDec(binary, 20, 23);


### PR DESCRIPTION
In line 88 the end value of binToDec should be 35 an not 36.
Comparing the other lines you can see that each number consists of 4 bits (nibble)
When you correct the value to 35 the checksum matches and the protocol works for me.