### PR TITLE
Start pilight without forking and restart on failure when using systemd

### DIFF
--- a/res/init/pilight.systemd
+++ b/res/init/pilight.systemd
@@ -3,7 +3,8 @@ Description=pilight
 After=network-online.target
 
 [Service]
-ExecStart=/usr/local/sbin/pilight-daemon -F
+ExecStart=/usr/local/sbin/pilight-daemon
+Type=forking
 Restart=on-failure
 
 [Install]

--- a/res/init/pilight.systemd
+++ b/res/init/pilight.systemd
@@ -3,8 +3,8 @@ Description=pilight
 After=network-online.target
 
 [Service]
-ExecStart=/usr/local/sbin/pilight-daemon
-Type=forking
+ExecStart=/usr/local/sbin/pilight-daemon -F
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This pull request starts pilight without forking when running as a systemd services. This is the recommended starting method according to [1]. It also enables restarting on failure [2], which restarts the pilight daemon in case of an unexpected error and thus increases the reliability of the system.

[1] https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=
[2] https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=