### PR TITLE
FIX: Condition to ensure sender GPIO pin is LOW after TX

### DIFF
--- a/libs/pilight/hardware/433gpio.lua
+++ b/libs/pilight/hardware/433gpio.lua
@@ -47,9 +47,7 @@ function M.send(timer)
 			-- Make sure we don't leave the GPIO dangling
 			-- in HIGH position.
 			--
-			if (count % 2) ~= 0 then
-				wx.digitalWrite(sender, 0);
-			end
+			wx.digitalWrite(sender, 0);
 		end
 	end
 

--- a/libs/pilight/hardware/433gpio.lua
+++ b/libs/pilight/hardware/433gpio.lua
@@ -47,7 +47,7 @@ function M.send(timer)
 			-- Make sure we don't leave the GPIO dangling
 			-- in HIGH position.
 			--
-			if (count % 2) == 0 then
+			if (count % 2) ~= 0 then
 				wx.digitalWrite(sender, 0);
 			end
 		end


### PR DESCRIPTION
Need to write an extra 0 to the GPIO pin in case the protocol is requiring an ODD number of pulses

See discussion here: https://forum.pilight.org/showthread.php?tid=3621