### PR TITLE
Updated MIN_PULSE_LENGTH for KaKu APIR-2150 support

### DIFF
--- a/libs/pilight/protocols/433.92/arctech_motion.c
+++ b/libs/pilight/protocols/433.92/arctech_motion.c
@@ -30,7 +30,7 @@
 #include "arctech_motion.h"
 
 #define PULSE_MULTIPLIER	3
-#define MIN_PULSE_LENGTH	250
+#define MIN_PULSE_LENGTH	160
 #define MAX_PULSE_LENGTH	284
 #define AVG_PULSE_LENGTH	279
 #define RAW_LENGTH				132


### PR DESCRIPTION
Now supports KaKu/CoCo APIR-2150 outdoor motion sensors

I've tested with 2 KlikAanKlikUit (KaKu) APIR-2150 outdoor motion sensors. They were not recognised by the current protocol. Debugging the RAW signal learned that a lower MIN_PULSE_LENGTH value would fix this.

In a batch of 14 samples the value for arctech_motion->raw[arctech_motion->rawlen-1] was between 5655 and 5662. Dividing with the PULSE_DIV of 34 a value of 165 would suffice. I chose 160 to be a bit on the safe side.

