### PR TITLE
fix(webserver): enable tcp backlog

### DIFF
--- a/inc/defines.h.in
+++ b/inc/defines.h.in
@@ -52,6 +52,8 @@
 	#define MQTT_ENABLE						1
 #endif
 
+#define TCP_BACKLOG							511 // comparable to apache, nginx, etc.
+
 #define MAX_CLIENTS							30
 #define BUFFER_SIZE							1025
 #define WIRINGX_BUFFER					4096

--- a/libs/pilight/core/mqtt-server.c
+++ b/libs/pilight/core/mqtt-server.c
@@ -883,7 +883,7 @@ int mqtt_server(int port) {
 		/*LCOV_EXCL_STOP*/
 	}
 
-	if((listen(sockfd, 3)) < 0) {
+	if((listen(sockfd, TCP_BACKLOG)) < 0) {
 		/*LCOV_EXCL_START*/
 		logprintf(LOG_ERR, "listen: %s", strerror(errno));
 #ifdef _WIN32

--- a/libs/pilight/core/mqtt-server.c
+++ b/libs/pilight/core/mqtt-server.c
@@ -883,7 +883,7 @@ int mqtt_server(int port) {
 		/*LCOV_EXCL_STOP*/
 	}
 
-	if((listen(sockfd, 0)) < 0) {
+	if((listen(sockfd, 3)) < 0) {
 		/*LCOV_EXCL_START*/
 		logprintf(LOG_ERR, "listen: %s", strerror(errno));
 #ifdef _WIN32

--- a/libs/pilight/core/socket.c
+++ b/libs/pilight/core/socket.c
@@ -141,8 +141,7 @@ int socket_start(unsigned short port) {
 	}
 
 	int x = 0;
-	//try to specify maximum of 3 pending connections for the master socket
-	if((x = listen(socket_server, 3)) < 0) {
+	if((x = listen(socket_server, TCP_BACKLOG)) < 0) {
 		logprintf(LOG_ERR, "failed to listen to socket");
 		exit(EXIT_FAILURE);
 	}

--- a/libs/pilight/core/webserver.c
+++ b/libs/pilight/core/webserver.c
@@ -1989,7 +1989,7 @@ static int webserver_init(int port, int is_ssl) {
 		return -1;
 	}
 
-	if((listen(sockfd, 3)) < 0) {
+	if((listen(sockfd, TCP_BACKLOG)) < 0) {
 		/*LCOV_EXCL_START*/
 		logprintf(LOG_ERR, "listen: %s", strerror(errno));
 #ifdef _WIN32

--- a/libs/pilight/core/webserver.c
+++ b/libs/pilight/core/webserver.c
@@ -1989,7 +1989,7 @@ static int webserver_init(int port, int is_ssl) {
 		return -1;
 	}
 
-	if((listen(sockfd, 0)) < 0) {
+	if((listen(sockfd, 3)) < 0) {
 		/*LCOV_EXCL_START*/
 		logprintf(LOG_ERR, "listen: %s", strerror(errno));
 #ifdef _WIN32


### PR DESCRIPTION
This enables the tcp backlog in the webserver's `listen()` call.
The setting of `3` is copied from the core `socket.c`.
https://github.com/pilight/pilight/blob/8b10bfc790bc49960f7f3d3145aadf3446dcba4b/libs/pilight/core/socket.c#L145
See also https://forum.pilight.org/showthread.php?tid=3698 .