### PR TITLE
Centralize tcp listen backlog size

### DIFF
--- a/inc/defines.h.in
+++ b/inc/defines.h.in
@@ -43,6 +43,8 @@
 	#define MQTT_ENABLE						1
 #endif
 
+#define TCP_BACKLOG							511 // comparable to apache, nginx, etc.
+
 #define MAX_CLIENTS							30
 #define BUFFER_SIZE							1025
 #define MEMBUFFER								128

--- a/libs/pilight/core/mqtt-server.c
+++ b/libs/pilight/core/mqtt-server.c
@@ -883,7 +883,7 @@ int mqtt_server(int port) {
 		/*LCOV_EXCL_STOP*/
 	}
 
-	if((listen(sockfd, 0)) < 0) {
+	if((listen(sockfd, TCP_BACKLOG)) < 0) {
 		/*LCOV_EXCL_START*/
 		logprintf(LOG_ERR, "listen: %s", strerror(errno));
 #ifdef _WIN32

--- a/libs/pilight/core/socket.c
+++ b/libs/pilight/core/socket.c
@@ -522,7 +522,7 @@ int socket_start(unsigned short port, void (*read_cb)(int, char *, ssize_t, char
 		/*LCOV_EXCL_STOP*/
 	}
 
-	if((listen(sockfd, 0)) < 0) {
+	if((listen(sockfd, TCP_BACKLOG)) < 0) {
 		/*LCOV_EXCL_START*/
 		logprintf(LOG_ERR, "listen: %s", strerror(errno));
 #ifdef _WIN32

--- a/libs/pilight/core/webserver.c
+++ b/libs/pilight/core/webserver.c
@@ -1965,7 +1965,7 @@ static int webserver_init(int port, int is_ssl) {
 		return -1;
 	}
 
-	if((listen(sockfd, 0)) < 0) {
+	if((listen(sockfd, TCP_BACKLOG)) < 0) {
 		/*LCOV_EXCL_START*/
 		logprintf(LOG_ERR, "listen: %s", strerror(errno));
 #ifdef _WIN32


### PR DESCRIPTION
This should prevent synflood warnings.

See #463. I cherry-picked that merge commit and cleaned up `socket.c`, where the merge would have conflicts.