### PR TITLE
Fix build for ESP8266

### DIFF
--- a/libs/pilight/config/gui.h
+++ b/libs/pilight/config/gui.h
@@ -46,7 +46,7 @@ struct gui_elements_t {
 	struct gui_elements_t *next;
 };
 
-struct config_t *config_gui;
+extern struct config_t *config_gui;
 
 struct gui_values_t *gui_media(char *name);
 void gui_init(void);

--- a/libs/pilight/config/rules.c
+++ b/libs/pilight/config/rules.c
@@ -38,6 +38,8 @@
 #include "rules.h"
 #include "gui.h"
 
+struct config_t *config_rules;
+
 static struct rules_t *rules = NULL;
 
 static pthread_mutex_t mutex_lock;

--- a/libs/pilight/config/rules.h
+++ b/libs/pilight/config/rules.h
@@ -60,7 +60,7 @@ typedef struct rules_t {
 	struct rules_t *next;
 } rules_t;
 
-struct config_t *config_rules;
+extern struct config_t *config_rules;
 
 void rules_init(void);
 int rules_gc(void);

--- a/libs/pilight/core/dso.c
+++ b/libs/pilight/core/dso.c
@@ -28,6 +28,8 @@
 #include "log.h"
 #include "dso.h"
 
+struct dso_t *dso;
+
 void *dso_load(char *object) {
 #ifndef _WIN32
 	logprintf(LOG_STACK, "%s(...)", __FUNCTION__);

--- a/libs/pilight/core/dso.h
+++ b/libs/pilight/core/dso.h
@@ -33,7 +33,7 @@ typedef struct module_t {
 	const char *reqcommit;
 } module_t;
 
-struct dso_t *dso;
+extern struct dso_t *dso;
 
 void *dso_load(char *object);
 int dso_gc(void);

--- a/libs/pilight/core/fcache.c
+++ b/libs/pilight/core/fcache.c
@@ -29,6 +29,8 @@
 #include "log.h"
 #include "gc.h"
 
+struct fcache_t *fcache;
+
 int fcache_gc(void) {
 	logprintf(LOG_STACK, "%s(...)", __FUNCTION__);
 

--- a/libs/pilight/core/fcache.h
+++ b/libs/pilight/core/fcache.h
@@ -27,7 +27,7 @@ typedef struct fcache_t {
 	struct fcache_t *next;
 } fcaches_t;
 
-struct fcache_t *fcache;
+extern struct fcache_t *fcache;
 
 int fcache_gc(void);
 int fcache_add(char *filename);

--- a/libs/pilight/core/mem.h
+++ b/libs/pilight/core/mem.h
@@ -9,9 +9,6 @@
 #ifndef _MEM_H_
 #define _MEM_H_
 
-#include "../backtrace/backtrace.h"
-#include "../backtrace/backtrace-supported.h"
-
 #define OUT_OF_MEMORY fprintf(stderr, "out of memory in %s #%d\n", __FILE__, __LINE__),exit(EXIT_FAILURE);
 
 #ifdef __GNUC__

--- a/libs/pilight/core/sha256cache.c
+++ b/libs/pilight/core/sha256cache.c
@@ -19,6 +19,8 @@
 #include "log.h"
 #include "gc.h"
 
+struct sha256cache_t *sha256cache;
+
 int sha256cache_gc(void) {
 	struct sha256cache_t *tmp = sha256cache;
 	while(sha256cache) {

--- a/libs/pilight/core/sha256cache.h
+++ b/libs/pilight/core/sha256cache.h
@@ -29,7 +29,7 @@ typedef struct sha256cache_t {
 	struct sha256cache_t *next;
 } sha256cache_t;
 
-struct sha256cache_t *sha256cache;
+extern struct sha256cache_t *sha256cache;
 
 int sha256cache_gc(void);
 void sha256cache_remove_node(struct sha256cache_t **sha256cache, char *name);

--- a/libs/pilight/protocols/433.92/alecto_ws1700.c
+++ b/libs/pilight/protocols/433.92/alecto_ws1700.c
@@ -43,6 +43,8 @@ typedef struct settings_t {
 	struct settings_t *next;
 } settings_t;
 
+struct protocol_t *alecto_ws1700;
+
 static struct settings_t *settings = NULL;
 
 static int validate(void) {

--- a/libs/pilight/protocols/433.92/alecto_ws1700.h
+++ b/libs/pilight/protocols/433.92/alecto_ws1700.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *alecto_ws1700;
+extern struct protocol_t *alecto_ws1700;
 void alectoWS1700Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/alecto_wsd17.c
+++ b/libs/pilight/protocols/433.92/alecto_wsd17.c
@@ -36,6 +36,8 @@
 #define MAX_PULSE_LENGTH	275
 #define RAW_LENGTH				74
 
+struct protocol_t *alecto_wsd17;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/alecto_wsd17.h
+++ b/libs/pilight/protocols/433.92/alecto_wsd17.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *alecto_wsd17;
+extern struct protocol_t *alecto_wsd17;
 void alectoWSD17Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/alecto_wx500.c
+++ b/libs/pilight/protocols/433.92/alecto_wx500.c
@@ -41,6 +41,8 @@
 #define AVG_PULSE					(ZERO_PULSE+ONE_PULSE)/2
 #define RAW_LENGTH				74
 
+struct protocol_t *alecto_wx500;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/alecto_wx500.h
+++ b/libs/pilight/protocols/433.92/alecto_wx500.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *alecto_wx500;
+extern struct protocol_t *alecto_wx500;
 void alectoWX500Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_contact.c
+++ b/libs/pilight/protocols/433.92/arctech_contact.c
@@ -38,6 +38,8 @@
 #define MAX_RAW_LENGTH		148
 #define RAW_LENGTH				148
 
+struct protocol_t *arctech_contact;
+
 static int validate(void) {
 	if(arctech_contact->rawlen == MIN_RAW_LENGTH || arctech_contact->rawlen == MAX_RAW_LENGTH) {
 		if(arctech_contact->raw[arctech_contact->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_contact.h
+++ b/libs/pilight/protocols/433.92/arctech_contact.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_contact;
+extern struct protocol_t *arctech_contact;
 void arctechContactInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_dimmer.c
+++ b/libs/pilight/protocols/433.92/arctech_dimmer.c
@@ -39,6 +39,8 @@
 #define MAX_RAW_LENGTH		148
 #define MIN_RAW_LENGTH		132
 
+struct protocol_t *arctech_dimmer;
+
 static int validate(void) {
 	if(arctech_dimmer->rawlen == MAX_RAW_LENGTH || arctech_dimmer->rawlen == MIN_RAW_LENGTH) {
 		if(arctech_dimmer->raw[arctech_dimmer->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_dimmer.h
+++ b/libs/pilight/protocols/433.92/arctech_dimmer.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_dimmer;
+extern struct protocol_t *arctech_dimmer;
 void arctechDimmerInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_dusk.c
+++ b/libs/pilight/protocols/433.92/arctech_dusk.c
@@ -35,6 +35,8 @@
 #define AVG_PULSE_LENGTH	277
 #define RAW_LENGTH				132
 
+struct protocol_t *arctech_dusk;
+
 static int validate(void) {
 	if(arctech_dusk->rawlen == RAW_LENGTH) {
 		if(arctech_dusk->raw[arctech_dusk->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_dusk.h
+++ b/libs/pilight/protocols/433.92/arctech_dusk.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_dusk;
+extern struct protocol_t *arctech_dusk;
 void arctechDuskInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_motion.c
+++ b/libs/pilight/protocols/433.92/arctech_motion.c
@@ -35,6 +35,8 @@
 #define AVG_PULSE_LENGTH	279
 #define RAW_LENGTH				132
 
+struct protocol_t *arctech_motion;
+
 static int validate(void) {
 	if(arctech_motion->rawlen == RAW_LENGTH) {
 		if(arctech_motion->raw[arctech_motion->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_motion.h
+++ b/libs/pilight/protocols/433.92/arctech_motion.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_motion;
+extern struct protocol_t *arctech_motion;
 void arctechMotionInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_screen.c
+++ b/libs/pilight/protocols/433.92/arctech_screen.c
@@ -38,6 +38,8 @@
 #define AVG_PULSE_LENGTH	300
 #define RAW_LENGTH				132
 
+struct protocol_t *arctech_screen;
+
 static int validate(void) {
 	if(arctech_screen->rawlen == RAW_LENGTH) {
 		if(arctech_screen->raw[arctech_screen->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_screen.h
+++ b/libs/pilight/protocols/433.92/arctech_screen.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_screen;
+extern struct protocol_t *arctech_screen;
 void arctechScreenInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_screen_old.c
+++ b/libs/pilight/protocols/433.92/arctech_screen_old.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	335
 #define RAW_LENGTH				50
 
+struct protocol_t *arctech_screen_old;
+
 static int validate(void) {
 	if(arctech_screen_old->rawlen == RAW_LENGTH) {
 		if(arctech_screen_old->raw[arctech_screen_old->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_screen_old.h
+++ b/libs/pilight/protocols/433.92/arctech_screen_old.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_screen_old;
+extern struct protocol_t *arctech_screen_old;
 void arctechScreenOldInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_switch.c
+++ b/libs/pilight/protocols/433.92/arctech_switch.c
@@ -38,6 +38,8 @@
 #define AVG_PULSE_LENGTH	315
 #define RAW_LENGTH				132
 
+struct protocol_t *arctech_switch;
+
 static int validate(void) {
 	if(arctech_switch->rawlen == RAW_LENGTH) {
 		if(arctech_switch->raw[arctech_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_switch.h
+++ b/libs/pilight/protocols/433.92/arctech_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_switch;
+extern struct protocol_t *arctech_switch;
 void arctechSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/arctech_switch_old.c
+++ b/libs/pilight/protocols/433.92/arctech_switch_old.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	335
 #define RAW_LENGTH				50
 
+struct protocol_t *arctech_switch_old;
+
 static int validate(void) {
 	if(arctech_switch_old->rawlen == RAW_LENGTH) {
 		if(arctech_switch_old->raw[arctech_switch_old->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/arctech_switch_old.h
+++ b/libs/pilight/protocols/433.92/arctech_switch_old.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arctech_switch_old;
+extern struct protocol_t *arctech_switch_old;
 void arctechSwitchOldInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/auriol.c
+++ b/libs/pilight/protocols/433.92/auriol.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	269
 #define RAW_LENGTH				66
 
+struct protocol_t *auriol;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/auriol.h
+++ b/libs/pilight/protocols/433.92/auriol.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *auriol;
+extern struct protocol_t *auriol;
 void auriolInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/beamish_switch.c
+++ b/libs/pilight/protocols/433.92/beamish_switch.c
@@ -39,6 +39,8 @@
 
 static int map[7] = {0, 192, 48, 12, 3, 15, 195};
 
+struct protocol_t *beamish_switch;
+
 static int validate(void) {
 	if(beamish_switch->rawlen == RAW_LENGTH) {
 		if(beamish_switch->raw[beamish_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/beamish_switch.h
+++ b/libs/pilight/protocols/433.92/beamish_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *beamish_switch;
+extern struct protocol_t *beamish_switch;
 void beamishSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/clarus.c
+++ b/libs/pilight/protocols/433.92/clarus.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	180
 #define RAW_LENGTH				50
 
+struct protocol_t *clarus_switch;
+
 static int validate(void) {
 	if(clarus_switch->rawlen == RAW_LENGTH) {
 		if(clarus_switch->raw[clarus_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/clarus.h
+++ b/libs/pilight/protocols/433.92/clarus.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *clarus_switch;
+extern struct protocol_t *clarus_switch;
 void clarusSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/cleverwatts.c
+++ b/libs/pilight/protocols/433.92/cleverwatts.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	269
 #define RAW_LENGTH				50
 
+struct protocol_t *cleverwatts;
+
 static int validate(void) {
 	if(cleverwatts->rawlen == RAW_LENGTH) {
 		if(cleverwatts->raw[cleverwatts->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/cleverwatts.h
+++ b/libs/pilight/protocols/433.92/cleverwatts.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *cleverwatts;
+extern struct protocol_t *cleverwatts;
 void cleverwattsInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/conrad_rsl_contact.c
+++ b/libs/pilight/protocols/433.92/conrad_rsl_contact.c
@@ -35,6 +35,8 @@
 #define AVG_PULSE_LENGTH	190
 #define RAW_LENGTH				66
 
+struct protocol_t *conrad_rsl_contact;
+
 static int validate(void) {
 	if(conrad_rsl_contact->rawlen == RAW_LENGTH) {
 		if(conrad_rsl_contact->raw[conrad_rsl_contact->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/conrad_rsl_contact.h
+++ b/libs/pilight/protocols/433.92/conrad_rsl_contact.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *conrad_rsl_contact;
+extern struct protocol_t *conrad_rsl_contact;
 void conradRSLContactInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/conrad_rsl_switch.c
+++ b/libs/pilight/protocols/433.92/conrad_rsl_switch.c
@@ -40,6 +40,8 @@
 
 static int codes[5][4][2];
 
+struct protocol_t *conrad_rsl_switch;
+
 static int validate(void) {
 	if(conrad_rsl_switch->rawlen == RAW_LENGTH) {
 		if(conrad_rsl_switch->raw[conrad_rsl_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/conrad_rsl_switch.h
+++ b/libs/pilight/protocols/433.92/conrad_rsl_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *conrad_rsl_switch;
+extern struct protocol_t *conrad_rsl_switch;
 void conradRSLSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/daycom.c
+++ b/libs/pilight/protocols/433.92/daycom.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH        284
 #define RAW_LENGTH              50
 
+struct protocol_t *daycom;
+
 static int validate(void) {
 	if(daycom->rawlen == RAW_LENGTH) {
 		if(daycom->raw[daycom->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/daycom.h
+++ b/libs/pilight/protocols/433.92/daycom.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *daycom;
+extern struct protocol_t *daycom;
 void daycomInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/ehome.c
+++ b/libs/pilight/protocols/433.92/ehome.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	282
 #define RAW_LENGTH				50
 
+struct protocol_t *ehome;
+
 static int validate(void) {
 	if(ehome->rawlen == RAW_LENGTH) {
 		if(ehome->raw[ehome->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/ehome.h
+++ b/libs/pilight/protocols/433.92/ehome.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *ehome;
+extern struct protocol_t *ehome;
 void ehomeInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/elro_300_switch.c
+++ b/libs/pilight/protocols/433.92/elro_300_switch.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	302
 #define RAW_LENGTH				116
 
+struct protocol_t *elro_300_switch;
+
 static int validate(void) {
 	if(elro_300_switch->rawlen == RAW_LENGTH) {
 		if(elro_300_switch->raw[elro_300_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/elro_300_switch.h
+++ b/libs/pilight/protocols/433.92/elro_300_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *elro_300_switch;
+extern struct protocol_t *elro_300_switch;
 void elro300SwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/elro_400_switch.c
+++ b/libs/pilight/protocols/433.92/elro_400_switch.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	296
 #define RAW_LENGTH				50
 
+struct protocol_t *elro_400_switch;
+
 static int validate(void) {
 	if(elro_400_switch->rawlen == RAW_LENGTH) {
 		if(elro_400_switch->raw[elro_400_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/elro_400_switch.h
+++ b/libs/pilight/protocols/433.92/elro_400_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *elro_400_switch;
+extern struct protocol_t *elro_400_switch;
 void elro400SwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/elro_800_contact.c
+++ b/libs/pilight/protocols/433.92/elro_800_contact.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	300
 #define RAW_LENGTH				50
 
+struct protocol_t *elro_800_contact;
+
 static int validate(void) {
 	if(elro_800_contact->rawlen == RAW_LENGTH) {
 		if(elro_800_contact->raw[elro_800_contact->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/elro_800_contact.h
+++ b/libs/pilight/protocols/433.92/elro_800_contact.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *elro_800_contact;
+extern struct protocol_t *elro_800_contact;
 void elro800ContactInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/elro_800_switch.c
+++ b/libs/pilight/protocols/433.92/elro_800_switch.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	300
 #define RAW_LENGTH				50
 
+struct protocol_t *elro_800_switch;
+
 static int validate(void) {
 	if(elro_800_switch->rawlen == RAW_LENGTH) {
 		if(elro_800_switch->raw[elro_800_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/elro_800_switch.h
+++ b/libs/pilight/protocols/433.92/elro_800_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *elro_800_switch;
+extern struct protocol_t *elro_800_switch;
 void elro800SwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/eurodomest_switch.c
+++ b/libs/pilight/protocols/433.92/eurodomest_switch.c
@@ -60,6 +60,8 @@
 #define LEARN_REPEATS		40
 #define NORMAL_REPEATS		10
 
+struct protocol_t *eurodomest_switch;
+
 static int validate(void) {
 	if (eurodomest_switch->rawlen == RAW_LENGTH) {
 		if (eurodomest_switch->raw[eurodomest_switch->rawlen - 1] >= MIN_LONG_PULSE_LENGTH &&

--- a/libs/pilight/protocols/433.92/eurodomest_switch.h
+++ b/libs/pilight/protocols/433.92/eurodomest_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *eurodomest_switch;
+extern struct protocol_t *eurodomest_switch;
 void eurodomestSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/ev1527.c
+++ b/libs/pilight/protocols/433.92/ev1527.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	256
 #define RAW_LENGTH				50
 
+struct protocol_t *ev1527;
+
 static int validate(void) {
 	if(ev1527->rawlen == RAW_LENGTH) {
 		if(ev1527->raw[ev1527->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/ev1527.h
+++ b/libs/pilight/protocols/433.92/ev1527.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *ev1527;
+extern struct protocol_t *ev1527;
 void ev1527Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/fanju.c
+++ b/libs/pilight/protocols/433.92/fanju.c
@@ -62,6 +62,8 @@
 #define MSG_LENGTH       RAW_LENGTH / 2
 #define OFFSET           5
 
+struct protocol_t *fanju;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/fanju.h
+++ b/libs/pilight/protocols/433.92/fanju.h
@@ -12,7 +12,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *fanju;
+extern struct protocol_t *fanju;
 void fanjuInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/heitech.c
+++ b/libs/pilight/protocols/433.92/heitech.c
@@ -37,6 +37,8 @@
 #define AVG_PULSE_LENGTH	280
 #define RAW_LENGTH				50
 
+struct protocol_t *heitech;
+
 static int validate(void) {
 	if(heitech->rawlen == RAW_LENGTH) {
 		if(heitech->raw[heitech->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/heitech.h
+++ b/libs/pilight/protocols/433.92/heitech.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *heitech;
+extern struct protocol_t *heitech;
 void heitechInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/impuls.c
+++ b/libs/pilight/protocols/433.92/impuls.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	150
 #define RAW_LENGTH				50
 
+struct protocol_t *impuls;
+
 static int validate(void) {
 	if(impuls->rawlen == RAW_LENGTH) {
 		if(impuls->raw[impuls->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/impuls.h
+++ b/libs/pilight/protocols/433.92/impuls.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *impuls;
+extern struct protocol_t *impuls;
 void impulsInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/iwds07.c
+++ b/libs/pilight/protocols/433.92/iwds07.c
@@ -27,6 +27,8 @@
 #define FOOTER				14110
 #define RAW_LENGTH			50
 
+struct protocol_t *iwds07;
+
 static int validate(void) {
 	if(iwds07->rawlen == RAW_LENGTH) {
 		if(iwds07->raw[iwds07->rawlen-1] >= (FOOTER*0.9) &&

--- a/libs/pilight/protocols/433.92/iwds07.h
+++ b/libs/pilight/protocols/433.92/iwds07.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *iwds07;
+extern struct protocol_t *iwds07;
 void iwds07Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/kerui_d026.c
+++ b/libs/pilight/protocols/433.92/kerui_d026.c
@@ -26,6 +26,8 @@
 #define AVG_PULSE_LENGTH	280
 #define RAW_LENGTH		50
 
+struct protocol_t *kerui_D026;
+
 static int validate(void) {
 	if(kerui_D026->rawlen == RAW_LENGTH) {
 		if(kerui_D026->raw[kerui_D026->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/kerui_d026.h
+++ b/libs/pilight/protocols/433.92/kerui_d026.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *kerui_D026;
+extern struct protocol_t *kerui_D026;
 void keruiD026Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/logilink_switch.c
+++ b/libs/pilight/protocols/433.92/logilink_switch.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	284
 #define RAW_LENGTH				50
 
+struct protocol_t *logilink_switch;
+
 static int validate(void) {
 	if(logilink_switch->rawlen == RAW_LENGTH) {
 		if(logilink_switch->raw[logilink_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/logilink_switch.h
+++ b/libs/pilight/protocols/433.92/logilink_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *logilink_switch;
+extern struct protocol_t *logilink_switch;
 void logilinkSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/mumbi.c
+++ b/libs/pilight/protocols/433.92/mumbi.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	312
 #define RAW_LENGTH				50
 
+struct protocol_t *mumbi;
+
 static int validate(void) {
 	if(mumbi->rawlen == RAW_LENGTH) {
 		if(mumbi->raw[mumbi->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/mumbi.h
+++ b/libs/pilight/protocols/433.92/mumbi.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *mumbi;
+extern struct protocol_t *mumbi;
 void mumbiInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/nexus.c
+++ b/libs/pilight/protocols/433.92/nexus.c
@@ -45,6 +45,8 @@
 #define RAW_LENGTH (MESSAGE_BITS * 2 + 2)
 #define MAXBITS (RAW_LENGTH / 2)
 
+struct protocol_t *nexus;
+
 enum PulseType {
     START_P = 500,
     ZERO_P = 1000,

--- a/libs/pilight/protocols/433.92/nexus.h
+++ b/libs/pilight/protocols/433.92/nexus.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *nexus;
+extern struct protocol_t *nexus;
 void nexusInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/ninjablocks_weather.c
+++ b/libs/pilight/protocols/433.92/ninjablocks_weather.c
@@ -54,6 +54,8 @@ typedef struct settings_t {
 
 static struct settings_t *settings = NULL;
 
+struct protocol_t *ninjablocks_weather;
+
 static int validate(void) {
 	if(ninjablocks_weather->rawlen >= MIN_RAW_LENGTH && ninjablocks_weather->rawlen <= MAX_RAW_LENGTH) {
 		if(ninjablocks_weather->raw[ninjablocks_weather->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/ninjablocks_weather.h
+++ b/libs/pilight/protocols/433.92/ninjablocks_weather.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *ninjablocks_weather;
+extern struct protocol_t *ninjablocks_weather;
 void ninjablocksWeatherInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/pollin.c
+++ b/libs/pilight/protocols/433.92/pollin.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	301
 #define RAW_LENGTH				50
 
+struct protocol_t *pollin;
+
 static int validate(void) {
 	if(pollin->rawlen == RAW_LENGTH) {
 		if(pollin->raw[pollin->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/pollin.h
+++ b/libs/pilight/protocols/433.92/pollin.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *pollin;
+extern struct protocol_t *pollin;
 void pollinInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/quigg_gt1000.c
+++ b/libs/pilight/protocols/433.92/quigg_gt1000.c
@@ -78,6 +78,9 @@
 #define AVG_PULSE_LENGTH	330
 #define RAW_LENGTH				151
 #define BIN_LENGTH				24
+
+struct protocol_t *quigg_gt1000;
+
 /*
 // Support Rx
 static int validate(void) {

--- a/libs/pilight/protocols/433.92/quigg_gt1000.h
+++ b/libs/pilight/protocols/433.92/quigg_gt1000.h
@@ -25,7 +25,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *quigg_gt1000;
+extern struct protocol_t *quigg_gt1000;
 void quiggGT1000Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/quigg_gt7000.c
+++ b/libs/pilight/protocols/433.92/quigg_gt7000.c
@@ -43,6 +43,8 @@
 #define MAX_PULSE_LENGTH	AVG_PULSE_LENGTH+260
 #define RAW_LENGTH				42
 
+struct protocol_t *quigg_gt7000;
+
 static int validate(void) {
 	if(quigg_gt7000->rawlen == RAW_LENGTH) {
 		if(quigg_gt7000->raw[quigg_gt7000->rawlen-1] >= (int)(PULSE_QUIGG_FOOTER*0.9) &&

--- a/libs/pilight/protocols/433.92/quigg_gt7000.h
+++ b/libs/pilight/protocols/433.92/quigg_gt7000.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *quigg_gt7000;
+extern struct protocol_t *quigg_gt7000;
 void quiggGT7000Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/quigg_gt9000.c
+++ b/libs/pilight/protocols/433.92/quigg_gt9000.c
@@ -39,6 +39,8 @@
 #define AVG_PULSE_LENGTH	750
 #define RAW_LENGTH		50
 
+struct protocol_t *quigg_gt9000;
+
 /* Encoding details:
 	Bit
 	0-3      First part of systemcode

--- a/libs/pilight/protocols/433.92/quigg_gt9000.h
+++ b/libs/pilight/protocols/433.92/quigg_gt9000.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *quigg_gt9000;
+extern struct protocol_t *quigg_gt9000;
 void quiggGT9000Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/quigg_screen.c
+++ b/libs/pilight/protocols/433.92/quigg_screen.c
@@ -43,6 +43,8 @@
 #define MAX_PULSE_LENGTH	AVG_PULSE_LENGTH+260
 #define RAW_LENGTH				42
 
+struct protocol_t *quigg_screen;
+
 static int validate(void) {
 	if(quigg_screen->rawlen == RAW_LENGTH) {
 		if(quigg_screen->raw[quigg_screen->rawlen-1] >= (int)(PULSE_QUIGG_SCREEN_FOOTER*0.9) &&

--- a/libs/pilight/protocols/433.92/quigg_screen.h
+++ b/libs/pilight/protocols/433.92/quigg_screen.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *quigg_screen;
+extern struct protocol_t *quigg_screen;
 void quiggScreenInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/rc101.c
+++ b/libs/pilight/protocols/433.92/rc101.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	241
 #define RAW_LENGTH				66
 
+struct protocol_t *rc101;
+
 static int validate(void) {
 	if(rc101->rawlen == RAW_LENGTH) {
 		if(rc101->raw[rc101->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/rc101.h
+++ b/libs/pilight/protocols/433.92/rc101.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *rc101;
+extern struct protocol_t *rc101;
 void rc101Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/rsl366.c
+++ b/libs/pilight/protocols/433.92/rsl366.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	380
 #define RAW_LENGTH		50
 
+struct protocol_t *rsl366;
+
 static int validate(void) {
 	if(rsl366->rawlen == RAW_LENGTH) {
 		if(rsl366->raw[rsl366->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/rsl366.h
+++ b/libs/pilight/protocols/433.92/rsl366.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *rsl366;
+extern struct protocol_t *rsl366;
 void rsl366Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/sc2262.c
+++ b/libs/pilight/protocols/433.92/sc2262.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	432
 #define RAW_LENGTH				50
 
+struct protocol_t *sc2262;
+
 static int validate(void) {
 	if(sc2262->rawlen == RAW_LENGTH) {
 		if(sc2262->raw[sc2262->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/sc2262.h
+++ b/libs/pilight/protocols/433.92/sc2262.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *sc2262;
+extern struct protocol_t *sc2262;
 void sc2262Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/secudo_smoke.c
+++ b/libs/pilight/protocols/433.92/secudo_smoke.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	312
 #define RAW_LENGTH			26
 
+struct protocol_t *secudo_smoke;
+
 static int validate(void) {
 	if(secudo_smoke->rawlen == RAW_LENGTH) {
 		if(secudo_smoke->raw[secudo_smoke->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/secudo_smoke.h
+++ b/libs/pilight/protocols/433.92/secudo_smoke.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *secudo_smoke;
+extern struct protocol_t *secudo_smoke;
 void secudoSmokeInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/selectremote.c
+++ b/libs/pilight/protocols/433.92/selectremote.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	396
 #define RAW_LENGTH				50
 
+struct protocol_t *selectremote;
+
 static int validate(void) {
 	if(selectremote->rawlen == RAW_LENGTH) {
 		if(selectremote->raw[selectremote->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/selectremote.h
+++ b/libs/pilight/protocols/433.92/selectremote.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *selectremote;
+extern struct protocol_t *selectremote;
 void selectremoteInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/silvercrest.c
+++ b/libs/pilight/protocols/433.92/silvercrest.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	312
 #define RAW_LENGTH				50
 
+struct protocol_t *silvercrest;
+
 static int validate(void) {
 	if(silvercrest->rawlen == RAW_LENGTH) {
 		if(silvercrest->raw[silvercrest->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/silvercrest.h
+++ b/libs/pilight/protocols/433.92/silvercrest.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *silvercrest;
+extern struct protocol_t *silvercrest;
 void silvercrestInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/smartwares_switch.c
+++ b/libs/pilight/protocols/433.92/smartwares_switch.c
@@ -28,6 +28,8 @@
 #define AVG_PULSE_LENGTH	300
 #define RAW_LENGTH				132
 
+struct protocol_t *smartwares_switch;
+
 static int validate(void) {
 	if(smartwares_switch->rawlen == RAW_LENGTH) {
 		if(smartwares_switch->raw[smartwares_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/smartwares_switch.h
+++ b/libs/pilight/protocols/433.92/smartwares_switch.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *smartwares_switch;
+extern struct protocol_t *smartwares_switch;
 void smartwaresSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/tcm.c
+++ b/libs/pilight/protocols/433.92/tcm.c
@@ -46,6 +46,8 @@
 	25-36	temperature (signed int12)
 */
 
+struct protocol_t *tcm;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/tcm.h
+++ b/libs/pilight/protocols/433.92/tcm.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *tcm;
+extern struct protocol_t *tcm;
 void tcmInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/techlico_switch.c
+++ b/libs/pilight/protocols/433.92/techlico_switch.c
@@ -39,6 +39,8 @@
 
 static int map[NRMAP]={0, 3, 192, 15, 12};
 
+struct protocol_t *techlico_switch;
+
 static int validate(void) {
 	if(techlico_switch->rawlen == RAW_LENGTH) {
 		if(techlico_switch->raw[techlico_switch->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/techlico_switch.h
+++ b/libs/pilight/protocols/433.92/techlico_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *techlico_switch;
+extern struct protocol_t *techlico_switch;
 void techlicoSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/teknihall.c
+++ b/libs/pilight/protocols/433.92/teknihall.c
@@ -36,6 +36,8 @@
 #define AVG_PULSE_LENGTH	266
 #define RAW_LENGTH				76
 
+struct protocol_t *teknihall;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/teknihall.h
+++ b/libs/pilight/protocols/433.92/teknihall.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *teknihall;
+extern struct protocol_t *teknihall;
 void teknihallInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/tfa.c
+++ b/libs/pilight/protocols/433.92/tfa.c
@@ -39,6 +39,8 @@
 #define MED_RAW_LENGTH		86	// TFA
 #define MAX_RAW_LENGTH		88	// DOSTMAN 32.3200
 
+struct protocol_t *tfa;
+
 typedef struct settings_t {
 	double id;
 	double channel;

--- a/libs/pilight/protocols/433.92/tfa.h
+++ b/libs/pilight/protocols/433.92/tfa.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *tfa;
+extern struct protocol_t *tfa;
 void tfaInit(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/tfa2017.c
+++ b/libs/pilight/protocols/433.92/tfa2017.c
@@ -25,6 +25,8 @@
 #define MAX_RAW_LENGTH		400
 #define MESSAGE_LENGTH		48
 
+struct protocol_t *tfa2017;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/tfa2017.h
+++ b/libs/pilight/protocols/433.92/tfa2017.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *tfa2017;
+extern struct protocol_t *tfa2017;
 void tfa2017Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/tfa30.c
+++ b/libs/pilight/protocols/433.92/tfa30.c
@@ -45,6 +45,8 @@
 #define MAX_RAW_LENGTH		88
 #define RAW_LENGTH				88
 
+struct protocol_t *tfa30;
+
 typedef struct settings_t {
 	double id;
 	double temp;

--- a/libs/pilight/protocols/433.92/tfa30.h
+++ b/libs/pilight/protocols/433.92/tfa30.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *tfa30;
+extern struct protocol_t *tfa30;
 void tfa30Init(void);
 
 #endif

--- a/libs/pilight/protocols/433.92/x10.c
+++ b/libs/pilight/protocols/433.92/x10.c
@@ -38,6 +38,8 @@
 
 static char letters[18] = {"MNOPCDABEFGHKL IJ"};
 
+struct protocol_t *x10;
+
 static int validate(void) {
 	if(x10->rawlen == RAW_LENGTH) {
 		if(x10->raw[x10->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/433.92/x10.h
+++ b/libs/pilight/protocols/433.92/x10.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *x10;
+extern struct protocol_t *x10;
 void x10Init(void);
 
 #endif

--- a/libs/pilight/protocols/API/cpu_temp.c
+++ b/libs/pilight/protocols/API/cpu_temp.c
@@ -45,6 +45,8 @@
 #include "../../core/gc.h"
 #include "cpu_temp.h"
 
+struct protocol_t *cpuTemp;
+
 #ifndef _WIN32
 #ifdef PILIGHT_DEVELOPMENT
 static unsigned short loop = 1;

--- a/libs/pilight/protocols/API/cpu_temp.h
+++ b/libs/pilight/protocols/API/cpu_temp.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *cpuTemp;
+extern struct protocol_t *cpuTemp;
 void cpuTempInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/datetime.c
+++ b/libs/pilight/protocols/API/datetime.c
@@ -60,6 +60,8 @@
 #include "../../core/datetime.h"
 #include "datetime.h"
 
+struct protocol_t *datetime;
+
 #ifdef PILIGHT_DEVELOPMENT
 static unsigned short loop = 1;
 static unsigned short threads = 0;

--- a/libs/pilight/protocols/API/datetime.h
+++ b/libs/pilight/protocols/API/datetime.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *datetime;
+extern struct protocol_t *datetime;
 void datetimeInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/lirc.c
+++ b/libs/pilight/protocols/API/lirc.c
@@ -54,6 +54,8 @@
 #include "../../core/gc.h"
 #include "lirc.h"
 
+struct protocol_t *lirc;
+
 #ifndef _WIN32
 static char socket_path[BUFFER_SIZE];
 static int sockfd = -1;

--- a/libs/pilight/protocols/API/lirc.h
+++ b/libs/pilight/protocols/API/lirc.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *lirc;
+extern struct protocol_t *lirc;
 void lircInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/openweathermap.c
+++ b/libs/pilight/protocols/API/openweathermap.c
@@ -52,6 +52,8 @@
 
 #define INTERVAL 	600
 
+struct protocol_t *openweathermap;
+
 #ifdef PILIGHT_DEVELOPMENT
 typedef struct settings_t {
 	char *country;

--- a/libs/pilight/protocols/API/openweathermap.h
+++ b/libs/pilight/protocols/API/openweathermap.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *openweathermap;
+extern struct protocol_t *openweathermap;
 void openweathermapInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/program.c
+++ b/libs/pilight/protocols/API/program.c
@@ -46,6 +46,8 @@
 #include "../../core/gc.h"
 #include "program.h"
 
+struct protocol_t *program;
+
 #ifndef _WIN32
 static unsigned short loop = 1;
 static unsigned short threads = 0;

--- a/libs/pilight/protocols/API/program.h
+++ b/libs/pilight/protocols/API/program.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *program;
+extern struct protocol_t *program;
 void programInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/shelly1.c
+++ b/libs/pilight/protocols/API/shelly1.c
@@ -36,6 +36,8 @@
 #include "../../lua_c/table.h"
 #include "shelly1.h"
 
+struct protocol_t *shellySwitch;
+
 static void *reason_send_code_free(void *param) {
 	plua_metatable_free(param);
 	return NULL;

--- a/libs/pilight/protocols/API/shelly1.h
+++ b/libs/pilight/protocols/API/shelly1.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *shellySwitch;
+extern struct protocol_t *shellySwitch;
 void shellySwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/shelly1pm.c
+++ b/libs/pilight/protocols/API/shelly1pm.c
@@ -36,6 +36,8 @@
 #include "../../lua_c/table.h"
 #include "shelly1pm.h"
 
+struct protocol_t *shellySwitchPM;
+
 static void *reason_send_code_free(void *param) {
 	plua_metatable_free(param);
 	return NULL;

--- a/libs/pilight/protocols/API/shelly1pm.h
+++ b/libs/pilight/protocols/API/shelly1pm.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *shellySwitchPM;
+extern struct protocol_t *shellySwitchPM;
 void shellySwitchPMInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/shellydimmer2.c
+++ b/libs/pilight/protocols/API/shellydimmer2.c
@@ -36,6 +36,8 @@
 #include "../../lua_c/table.h"
 #include "shellydimmer2.h"
 
+struct protocol_t *shellyDimmer2;
+
 static void *reason_send_code_free(void *param) {
 	plua_metatable_free(param);
 	return NULL;

--- a/libs/pilight/protocols/API/shellydimmer2.h
+++ b/libs/pilight/protocols/API/shellydimmer2.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *shellyDimmer2;
+extern struct protocol_t *shellyDimmer2;
 void shellyDimmer2Init(void);
 
 #endif

--- a/libs/pilight/protocols/API/shellyplug.c
+++ b/libs/pilight/protocols/API/shellyplug.c
@@ -36,6 +36,8 @@
 #include "../../lua_c/table.h"
 #include "shellyplug.h"
 
+struct protocol_t *shellyPlug;
+
 static void *reason_send_code_free(void *param) {
 	plua_metatable_free(param);
 	return NULL;

--- a/libs/pilight/protocols/API/shellyplug.h
+++ b/libs/pilight/protocols/API/shellyplug.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *shellyPlug;
+extern struct protocol_t *shellyPlug;
 void shellyPlugInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/shellyplug_s.c
+++ b/libs/pilight/protocols/API/shellyplug_s.c
@@ -34,6 +34,8 @@
 #include "../../lua_c/table.h"
 #include "shellyplug_s.h"
 
+struct protocol_t *shellyPlugS;
+
 static void *reason_send_code_free(void *param) {
 	plua_metatable_free(param);
 	return NULL;

--- a/libs/pilight/protocols/API/shellyplug_s.h
+++ b/libs/pilight/protocols/API/shellyplug_s.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *shellyPlugS;
+extern struct protocol_t *shellyPlugS;
 void shellyPlugSInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/sunriseset.c
+++ b/libs/pilight/protocols/API/sunriseset.c
@@ -49,6 +49,8 @@
 #define PIX 57.29578049044297 // 180 / PI
 #define ZENITH 90.83333333333333
 
+struct protocol_t *sunriseset;
+
 #ifdef PILIGHT_DEVELOPMENT
 static unsigned short loop = 1;
 static unsigned short threads = 0;

--- a/libs/pilight/protocols/API/sunriseset.h
+++ b/libs/pilight/protocols/API/sunriseset.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *sunriseset;
+extern struct protocol_t *sunriseset;
 void sunRiseSetInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/tasmota_switch.c
+++ b/libs/pilight/protocols/API/tasmota_switch.c
@@ -36,6 +36,8 @@
 #include "../../lua_c/table.h"
 #include "tasmota_switch.h"
 
+struct protocol_t *tasmotaSwitch;
+
 static void *reason_send_code_free(void *param) {
 	plua_metatable_free(param);
 	return NULL;

--- a/libs/pilight/protocols/API/tasmota_switch.h
+++ b/libs/pilight/protocols/API/tasmota_switch.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *tasmotaSwitch;
+extern struct protocol_t *tasmotaSwitch;
 void tasmotaSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/wunderground.c
+++ b/libs/pilight/protocols/API/wunderground.c
@@ -49,6 +49,8 @@
 
 #define INTERVAL	900
 
+struct protocol_t *wunderground;
+
 #ifdef PILIGHT_DEVELOPMENT
 typedef struct settings_t {
 	char *api;

--- a/libs/pilight/protocols/API/wunderground.h
+++ b/libs/pilight/protocols/API/wunderground.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *wunderground;
+extern struct protocol_t *wunderground;
 void wundergroundInit(void);
 
 #endif

--- a/libs/pilight/protocols/API/xbmc.c
+++ b/libs/pilight/protocols/API/xbmc.c
@@ -57,6 +57,8 @@
 #include "../../core/gc.h"
 #include "xbmc.h"
 
+struct protocol_t *xbmc;
+
 typedef struct data_t {
 	char *server;
 	int port;

--- a/libs/pilight/protocols/API/xbmc.h
+++ b/libs/pilight/protocols/API/xbmc.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *xbmc;
+extern struct protocol_t *xbmc;
 void xbmcInit(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/bme280.c
+++ b/libs/pilight/protocols/GPIO/bme280.c
@@ -38,6 +38,8 @@
 #include "../protocol.h"
 #include "bme280.h"
 
+struct protocol_t *bme280;
+
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 
 typedef struct settings_t {

--- a/libs/pilight/protocols/GPIO/bme280.h
+++ b/libs/pilight/protocols/GPIO/bme280.h
@@ -11,7 +11,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *bme280;
+extern struct protocol_t *bme280;
 void bme280Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/bmp180.c
+++ b/libs/pilight/protocols/GPIO/bmp180.c
@@ -48,6 +48,8 @@
 #include "../protocol.h"
 #include "bmp180.h"
 
+struct protocol_t *bmp180;
+
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 
 typedef struct settings_t {

--- a/libs/pilight/protocols/GPIO/bmp180.h
+++ b/libs/pilight/protocols/GPIO/bmp180.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *bmp180;
+extern struct protocol_t *bmp180;
 void bmp180Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/dht11.c
+++ b/libs/pilight/protocols/GPIO/dht11.c
@@ -50,6 +50,8 @@
 
 #define MAXTIMINGS 100
 
+struct protocol_t *dht11;
+
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 
 static unsigned short loop = 1;

--- a/libs/pilight/protocols/GPIO/dht11.h
+++ b/libs/pilight/protocols/GPIO/dht11.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *dht11;
+extern struct protocol_t *dht11;
 void dht11Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/dht22.c
+++ b/libs/pilight/protocols/GPIO/dht22.c
@@ -50,6 +50,8 @@
 
 #define MAXTIMINGS 100
 
+struct protocol_t *dht22;
+
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 
 static unsigned short loop = 1;

--- a/libs/pilight/protocols/GPIO/dht22.h
+++ b/libs/pilight/protocols/GPIO/dht22.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *dht22;
+extern struct protocol_t *dht22;
 void dht22Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/ds18b20.c
+++ b/libs/pilight/protocols/GPIO/ds18b20.c
@@ -44,6 +44,8 @@
 #include "../../core/gc.h"
 #include "ds18b20.h"
 
+struct protocol_t *ds18b20;
+
 static unsigned short loop = 1;
 static unsigned short threads = 0;
 static char source_path[21];

--- a/libs/pilight/protocols/GPIO/ds18b20.h
+++ b/libs/pilight/protocols/GPIO/ds18b20.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *ds18b20;
+extern struct protocol_t *ds18b20;
 void ds18b20Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/ds18s20.c
+++ b/libs/pilight/protocols/GPIO/ds18s20.c
@@ -45,6 +45,8 @@
 #include "../../core/gc.h"
 #include "ds18s20.h"
 
+struct protocol_t *ds18s20;
+
 static unsigned short loop = 1;
 static unsigned short threads = 0;
 static char source_path[21];

--- a/libs/pilight/protocols/GPIO/ds18s20.h
+++ b/libs/pilight/protocols/GPIO/ds18s20.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *ds18s20;
+extern struct protocol_t *ds18s20;
 void ds18s20Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/gpio_switch.c
+++ b/libs/pilight/protocols/GPIO/gpio_switch.c
@@ -37,6 +37,8 @@
 #include "../protocol.h"
 #include "gpio_switch.h"
 
+struct protocol_t *gpio_switch;
+
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 
 static unsigned short loop = 1;

--- a/libs/pilight/protocols/GPIO/gpio_switch.h
+++ b/libs/pilight/protocols/GPIO/gpio_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *gpio_switch;
+extern struct protocol_t *gpio_switch;
 void gpioSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/lm75.c
+++ b/libs/pilight/protocols/GPIO/lm75.c
@@ -48,6 +48,8 @@
 #include "../protocol.h"
 #include "lm75.h"
 
+struct protocol_t *lm75;
+
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 typedef struct settings_t {
 	char **id;

--- a/libs/pilight/protocols/GPIO/lm75.h
+++ b/libs/pilight/protocols/GPIO/lm75.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *lm75;
+extern struct protocol_t *lm75;
 void lm75Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/lm76.c
+++ b/libs/pilight/protocols/GPIO/lm76.c
@@ -48,6 +48,8 @@
 #include "../protocol.h"
 #include "lm76.h"
 
+struct protocol_t *lm76;
+
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 typedef struct settings_t {
 	char **id;

--- a/libs/pilight/protocols/GPIO/lm76.h
+++ b/libs/pilight/protocols/GPIO/lm76.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *lm76;
+extern struct protocol_t *lm76;
 void lm76Init(void);
 
 #endif

--- a/libs/pilight/protocols/GPIO/relay.c
+++ b/libs/pilight/protocols/GPIO/relay.c
@@ -38,6 +38,8 @@
 
 #include "defines.h"
 
+struct protocol_t *relay;
+
 static char *state = NULL;
 #if !defined(__FreeBSD__) && !defined(_WIN32)
 

--- a/libs/pilight/protocols/GPIO/relay.h
+++ b/libs/pilight/protocols/GPIO/relay.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *relay;
+extern struct protocol_t *relay;
 void relayInit(void);
 
 #endif

--- a/libs/pilight/protocols/core/pilight_firmware_v2.c
+++ b/libs/pilight/protocols/core/pilight_firmware_v2.c
@@ -35,6 +35,8 @@
 #define AVG_PULSE_LENGTH	183
 #define RAW_LENGTH				196
 
+struct protocol_t *pilight_firmware_v2;
+
 static int validate(void) {
 	if(pilight_firmware_v2->rawlen == RAW_LENGTH) {
 		if(pilight_firmware_v2->raw[pilight_firmware_v2->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/core/pilight_firmware_v2.h
+++ b/libs/pilight/protocols/core/pilight_firmware_v2.h
@@ -19,7 +19,7 @@
 #ifndef _PROTOCOL_PILIGHT_FIRMWARE_V2_H_
 #define _PROTOCOL_PILIGHT_FIRMWARE_V2_H_
 
-struct protocol_t *pilight_firmware_v2;
+extern struct protocol_t *pilight_firmware_v2;
 void pilightFirmwareV2Init(void);
 
 #endif

--- a/libs/pilight/protocols/core/pilight_firmware_v3.c
+++ b/libs/pilight/protocols/core/pilight_firmware_v3.c
@@ -35,6 +35,8 @@
 #define AVG_PULSE_LENGTH	225
 #define RAW_LENGTH				212
 
+struct protocol_t *pilight_firmware_v3;
+
 static int validate(void) {
 	if(pilight_firmware_v3->rawlen == RAW_LENGTH) {
 		if(pilight_firmware_v3->raw[pilight_firmware_v3->rawlen-1] >= (MIN_PULSE_LENGTH*PULSE_DIV) &&

--- a/libs/pilight/protocols/core/pilight_firmware_v3.h
+++ b/libs/pilight/protocols/core/pilight_firmware_v3.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *pilight_firmware_v3;
+extern struct protocol_t *pilight_firmware_v3;
 void pilightFirmwareV3Init(void);
 
 #endif

--- a/libs/pilight/protocols/core/raw.c
+++ b/libs/pilight/protocols/core/raw.c
@@ -29,6 +29,8 @@
 #include "../../core/gc.h"
 #include "raw.h"
 
+struct protocol_t *raw;
+
 static int createCode(JsonNode *code) {
 	char *rcode = NULL;
 	double repeats = 10;

--- a/libs/pilight/protocols/core/raw.h
+++ b/libs/pilight/protocols/core/raw.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *raw;
+extern struct protocol_t *raw;
 void rawInit(void);
 
 #endif

--- a/libs/pilight/protocols/generic/generic_dimmer.c
+++ b/libs/pilight/protocols/generic/generic_dimmer.c
@@ -19,6 +19,8 @@
 #include "../../core/binary.h"
 #include "generic_dimmer.h"
 
+struct protocol_t *generic_dimmer;
+
 static void createMessage(int id, int state, int dimlevel) {
 	generic_dimmer->message = json_mkobject();
 	json_append_member(generic_dimmer->message, "id", json_mknumber(id, 0));

--- a/libs/pilight/protocols/generic/generic_dimmer.h
+++ b/libs/pilight/protocols/generic/generic_dimmer.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *generic_dimmer;
+extern struct protocol_t *generic_dimmer;
 void genericDimmerInit(void);
 
 #endif

--- a/libs/pilight/protocols/generic/generic_label.c
+++ b/libs/pilight/protocols/generic/generic_label.c
@@ -30,6 +30,8 @@
 #include "../../core/gc.h"
 #include "generic_label.h"
 
+struct protocol_t *generic_label;
+
 static void createMessage(int id, char *label, char *color) {
 	generic_label->message = json_mkobject();
 	json_append_member(generic_label->message, "id", json_mknumber(id, 0));

--- a/libs/pilight/protocols/generic/generic_label.h
+++ b/libs/pilight/protocols/generic/generic_label.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *generic_label;
+extern struct protocol_t *generic_label;
 void genericLabelInit(void);
 
 #endif

--- a/libs/pilight/protocols/generic/generic_screen.c
+++ b/libs/pilight/protocols/generic/generic_screen.c
@@ -30,6 +30,8 @@
 #include "../../core/gc.h"
 #include "generic_screen.h"
 
+struct protocol_t *generic_screen;
+
 static void createMessage(int id, int state) {
 	generic_screen->message = json_mkobject();
 	json_append_member(generic_screen->message, "id", json_mknumber(id, 1));

--- a/libs/pilight/protocols/generic/generic_screen.h
+++ b/libs/pilight/protocols/generic/generic_screen.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *generic_screen;
+extern struct protocol_t *generic_screen;
 void genericScreenInit(void);
 
 #endif

--- a/libs/pilight/protocols/generic/generic_switch.c
+++ b/libs/pilight/protocols/generic/generic_switch.c
@@ -30,6 +30,8 @@
 #include "../../core/gc.h"
 #include "generic_switch.h"
 
+struct protocol_t *generic_switch;
+
 static void createMessage(int id, int state) {
 	generic_switch->message = json_mkobject();
 	json_append_member(generic_switch->message, "id", json_mknumber(id, 0));

--- a/libs/pilight/protocols/generic/generic_switch.h
+++ b/libs/pilight/protocols/generic/generic_switch.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *generic_switch;
+extern struct protocol_t *generic_switch;
 void genericSwitchInit(void);
 
 #endif

--- a/libs/pilight/protocols/generic/generic_weather.c
+++ b/libs/pilight/protocols/generic/generic_weather.c
@@ -30,6 +30,8 @@
 #include "../../core/gc.h"
 #include "generic_weather.h"
 
+struct protocol_t *generic_weather;
+
 static void createMessage(int id, double temperature, double humidity, int battery) {
 	generic_weather->message = json_mkobject();
 	json_append_member(generic_weather->message, "id", json_mknumber(id, 0));

--- a/libs/pilight/protocols/generic/generic_weather.h
+++ b/libs/pilight/protocols/generic/generic_weather.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *generic_weather;
+extern struct protocol_t *generic_weather;
 void genericWeatherInit(void);
 
 #endif

--- a/libs/pilight/protocols/generic/generic_webcam.c
+++ b/libs/pilight/protocols/generic/generic_webcam.c
@@ -30,6 +30,8 @@
 #include "../../core/gc.h"
 #include "generic_webcam.h"
 
+struct protocol_t *generic_webcam;
+
 static int checkValues(JsonNode *code) {
 	int height = 300;
 	double itmp = -1;

--- a/libs/pilight/protocols/generic/generic_webcam.h
+++ b/libs/pilight/protocols/generic/generic_webcam.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *generic_webcam;
+extern struct protocol_t *generic_webcam;
 void genericWebcamInit(void);
 
 #endif

--- a/libs/pilight/protocols/network/arping.c
+++ b/libs/pilight/protocols/network/arping.c
@@ -55,6 +55,8 @@
 #include "../../core/gc.h"
 #include "arping.h"
 
+struct protocol_t *arping;
+
 static unsigned short loop = 1;
 static unsigned short threads = 0;
 

--- a/libs/pilight/protocols/network/arping.h
+++ b/libs/pilight/protocols/network/arping.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *arping;
+extern struct protocol_t *arping;
 void arpingInit(void);
 
 #endif

--- a/libs/pilight/protocols/network/ping.c
+++ b/libs/pilight/protocols/network/ping.c
@@ -44,6 +44,8 @@
 #include "../../core/gc.h"
 #include "ping.h"
 
+struct protocol_t *pping;
+
 static unsigned short loop = 1;
 static unsigned short threads = 0;
 

--- a/libs/pilight/protocols/network/ping.h
+++ b/libs/pilight/protocols/network/ping.h
@@ -21,7 +21,7 @@
 
 #include "../protocol.h"
 
-struct protocol_t *pping;
+extern struct protocol_t *pping;
 void pingInit(void);
 
 #endif


### PR DESCRIPTION
## Declare global variables extern in header files
And define them in corresponding c files. GCC 10.1.0 changes the default compilation options to use -fno-common,
which means that by default, this project no longer links unless you override the default with -fcommon.

## Remove unnecessary include files
`backtrace.h` is included in `mem.c` only when DEBUG is enabled, I cannot see why they should always be included in `mem.h`.  In the context of ESPilight, `backtrace.h` isn't available.

~These changes allow the ESPilight build to complete in the context of OpenMQTTGateway, but I'm marking as a draft until I've tested it on an ESP8266~ Works for me on ESP8266