### PR TITLE
 hacks to build on Debian bookworm

### DIFF
--- a/libs/pilight/psutil/linux.c
+++ b/libs/pilight/psutil/linux.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
-#include <sys/sysctl.h>
 #include <sys/user.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/setup.sh
+++ b/setup.sh
@@ -109,7 +109,7 @@ else
 		fi
 		mkdir build
 		cd build
-		cmake ..
+		cmake -DCMAKE_C_FLAGS=-fcommon ..
 		make install
 	fi
 fi


### PR DESCRIPTION
I am trying to build on 
I added the the hack  ```cmake -DCMAKE_C_FLAGS=-fcommon ..```  to ``` setup.sh```

```#include <sys/sysctl.h> ``` is not necessary on Debian bookworm anymore

another change neccesary luajit version.  Would pilight work also with  ```#include <luajit-2.1/lua.h>``` ? 
I am made changes for staging and rewrite. Which one is the development branch?
thanks